### PR TITLE
Repair Sonarcloud so that it works with Jacoco

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -155,5 +155,11 @@ sonar {
         property("sonar.projectKey", "Assocify-Team_Assocify")
         property("sonar.organization", "assocify-team")
         property("sonar.host.url", "https://sonarcloud.io")
+        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
+        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
+        property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+        // Paths to JaCoCo XML coverage report files.
+        property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
     }
 }


### PR DESCRIPTION
When adding a test and running Jacoco, the pipeline that the system has 0% of coverage even if the tests are functional. It will be great to be able to repair Sonarcloud so that it recognize JacocoTestreport.