### PR TITLE
User Roles and permissions

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/AssociationAPITest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/AssociationAPITest.kt
@@ -48,7 +48,6 @@ class AssociationAPITest {
     // When
     assoAPI.addAllAssociations(listOf(association1, association2, association3))
 
-
     // Then
     val associations = assoAPI.getAssociations()
 

--- a/app/src/androidTest/java/com/github/se/assocify/AssociationAPITest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/AssociationAPITest.kt
@@ -5,7 +5,6 @@ import com.github.se.assocify.model.entities.Association
 import com.github.se.assocify.model.entities.Event
 import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
-import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
@@ -47,12 +46,11 @@ class AssociationAPITest {
             assoAPI.getNewId(), "caaaa", "description", "", "status", emptyList(), emptyList())
 
     // When
-    assoAPI.addAssociation(association1)
-    assoAPI.addAssociation(association2)
-    assoAPI.addAssociation(association3)
+    assoAPI.addAllAssociations(listOf(association1, association2, association3))
+
 
     // Then
-    val associations = Tasks.await(assoAPI.getAssociations())
+    val associations = assoAPI.getAssociations()
 
     assertEquals(3, associations.size)
   }
@@ -156,7 +154,7 @@ class AssociationAPITest {
     assoAPI.deleteAssociation(association1.uid)
 
     // Get the list of associations from the database
-    val associations = Tasks.await(assoAPI.getAssociations())
+    val associations = assoAPI.getAssociations()
 
     // Verify that the deleted association is no longer present
     assertEquals(1, associations.size)

--- a/app/src/androidTest/java/com/github/se/assocify/UserAPITest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/UserAPITest.kt
@@ -1,9 +1,10 @@
 package com.github.se.assocify
 
 import com.github.se.assocify.model.database.UserAPI
+import com.github.se.assocify.model.entities.Role
+import com.github.se.assocify.model.entities.User
 import com.google.firebase.firestore.FirebaseFirestore
-import org.junit.After
-import org.junit.Before
+import org.junit.Assert
 import org.junit.Test
 
 class UserAPITest {
@@ -11,9 +12,27 @@ class UserAPITest {
   private val db = FirebaseFirestore.getInstance()
   private val userAPI = UserAPI(db)
 
-  @Before fun setUp() {}
+  @Test
+  fun test() {
+    val user = User(userAPI.getNewId(), "Test", Role("Admin"))
+    userAPI.addUser(user)
+    val retrievedUser = userAPI.getUser(user.uid)
+    Assert.assertEquals(user, retrievedUser)
+    userAPI.deleteUser(user.uid)
+    Assert.assertThrows(Exception::class.java) { userAPI.getUser(user.uid) }
+  }
 
-  @After fun tearDown() {}
+  @Test
+  fun testAddAllRemoveAll() {
+    val allUsers = userAPI.getAllUsers()
+    userAPI.deleteAllUsers()
 
-  @Test fun test() {}
+    val shouldEmpty = userAPI.getAllUsers()
+    Assert.assertTrue(shouldEmpty.isEmpty())
+
+    userAPI.addAllUsers(allUsers)
+
+    val allUsersAfter = userAPI.getAllUsers()
+    Assert.assertEquals(allUsers, allUsersAfter)
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/model/database/AssociationAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AssociationAPI.kt
@@ -5,7 +5,6 @@ import com.github.se.assocify.model.entities.Association
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
 
-
 /**
  * API for interacting with the associations in the database
  *
@@ -14,12 +13,12 @@ import com.google.firebase.firestore.FirebaseFirestore
 class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
   override val collectionName: String = "associations"
 
-    /**
-     * Gets an association from the database
-     *
-     * @param id the id of the association to get
-     * @return the association with the given id
-     */
+  /**
+   * Gets an association from the database
+   *
+   * @param id the id of the association to get
+   * @return the association with the given id
+   */
   fun getAssociation(id: String): Association {
     return Tasks.await(
         db.collection(collectionName).document(id).get().continueWith { task ->
@@ -36,11 +35,11 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
         })
   }
 
-    /**
-     * Gets all associations from the database
-     *
-     * @return a list of all associations
-     */
+  /**
+   * Gets all associations from the database
+   *
+   * @return a list of all associations
+   */
   fun getAssociations(): List<Association> {
     return Tasks.await(
         db.collection(collectionName).get().continueWith { task ->
@@ -57,12 +56,12 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
         })
   }
 
-    /**
-     * Adds/edit an association to the database
-     *
-     * @param association the association to add/edit
-     */
-    fun addAssociation(association: Association) {
+  /**
+   * Adds/edit an association to the database
+   *
+   * @param association the association to add/edit
+   */
+  fun addAssociation(association: Association) {
     Tasks.await(
         db.collection(collectionName)
             .document(association.uid)
@@ -75,20 +74,18 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
             })
   }
 
-    /**
-     * Adds/edit a list of associations to the database
-     *
-     * @param associations the list of associations to add/edit
-     */
+  /**
+   * Adds/edit a list of associations to the database
+   *
+   * @param associations the list of associations to add/edit
+   */
   fun addAllAssociations(associations: List<Association>) {
     for (association in associations) {
       addAssociation(association)
     }
   }
 
-    /**
-     * Deletes an association from the database
-     */
+  /** Deletes an association from the database */
   fun deleteAllAssociations() {
     Tasks.await(
         db.collection(collectionName).get().addOnSuccessListener { querySnapshot ->
@@ -97,10 +94,10 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
           }
         })
   }
-    /**
-     * Deletes an association from the database
-     *
-     * @param id the id of the association to delete
-     */
+  /**
+   * Deletes an association from the database
+   *
+   * @param id the id of the association to delete
+   */
   fun deleteAssociation(id: String) = delete(id)
 }

--- a/app/src/main/java/com/github/se/assocify/model/database/AssociationAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AssociationAPI.kt
@@ -2,13 +2,24 @@ package com.github.se.assocify.model.database
 
 import android.util.Log
 import com.github.se.assocify.model.entities.Association
-import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
 
+
+/**
+ * API for interacting with the associations in the database
+ *
+ * @property db the Firestore database
+ */
 class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
   override val collectionName: String = "associations"
 
+    /**
+     * Gets an association from the database
+     *
+     * @param id the id of the association to get
+     * @return the association with the given id
+     */
   fun getAssociation(id: String): Association {
     return Tasks.await(
         db.collection(collectionName).document(id).get().continueWith { task ->
@@ -25,22 +36,33 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
         })
   }
 
-  fun getAssociations(): Task<List<Association>> {
-    return db.collection(collectionName).get().continueWithTask { task ->
-      if (!task.isSuccessful) {
-        throw task.exception!!
-      }
-      val associations = mutableListOf<Association>()
-      for (document in task.result!!.documents) {
-        val asso = document.toObject(Association::class.java)
-        associations.add(asso!!)
-      }
-
-      return@continueWithTask Tasks.forResult(associations)
-    }
+    /**
+     * Gets all associations from the database
+     *
+     * @return a list of all associations
+     */
+  fun getAssociations(): List<Association> {
+    return Tasks.await(
+        db.collection(collectionName).get().continueWith { task ->
+          if (task.isSuccessful) {
+            val associations = mutableListOf<Association>()
+            for (document in task.result!!.documents) {
+              val association = document.toObject(Association::class.java)
+              associations.add(association!!)
+            }
+            associations
+          } else {
+            throw task.exception ?: Exception("Unknown error occurred")
+          }
+        })
   }
 
-  fun addAssociation(association: Association) {
+    /**
+     * Adds/edit an association to the database
+     *
+     * @param association the association to add/edit
+     */
+    fun addAssociation(association: Association) {
     Tasks.await(
         db.collection(collectionName)
             .document(association.uid)
@@ -53,6 +75,20 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
             })
   }
 
+    /**
+     * Adds/edit a list of associations to the database
+     *
+     * @param associations the list of associations to add/edit
+     */
+  fun addAllAssociations(associations: List<Association>) {
+    for (association in associations) {
+      addAssociation(association)
+    }
+  }
+
+    /**
+     * Deletes an association from the database
+     */
   fun deleteAllAssociations() {
     Tasks.await(
         db.collection(collectionName).get().addOnSuccessListener { querySnapshot ->
@@ -61,6 +97,10 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
           }
         })
   }
-
+    /**
+     * Deletes an association from the database
+     *
+     * @param id the id of the association to delete
+     */
   fun deleteAssociation(id: String) = delete(id)
 }

--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -3,7 +3,11 @@ package com.github.se.assocify.model.database
 import com.github.se.assocify.model.entities.User
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
-
+/**
+ * API for interacting with the users in the database
+ *
+ * @property db the Firestore database
+ */
 class UserAPI(db: FirebaseFirestore) : FirebaseApi(db) {
   override val collectionName: String
     get() = "users"

--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -3,6 +3,7 @@ package com.github.se.assocify.model.database
 import com.github.se.assocify.model.entities.User
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
+
 /**
  * API for interacting with the users in the database
  *

--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -1,8 +1,95 @@
 package com.github.se.assocify.model.database
 
+import com.github.se.assocify.model.entities.User
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.FirebaseFirestore
 
 class UserAPI(db: FirebaseFirestore) : FirebaseApi(db) {
   override val collectionName: String
     get() = "users"
+
+  /**
+   * Gets a user from the database
+   *
+   * @param id the id of the user to get
+   * @return the user with the given id
+   */
+  fun getUser(id: String): User {
+    return Tasks.await(
+        db.collection(collectionName).document(id).get().continueWith { task ->
+          if (task.isSuccessful) {
+            val document = task.result
+            if (document != null && document.exists()) {
+              document.toObject(User::class.java)
+            } else {
+              throw Exception("No User found with ID: $id")
+            }
+          } else {
+            throw task.exception ?: Exception("Unknown error occurred")
+          }
+        })
+  }
+  /**
+   * Gets all users from the database
+   *
+   * @return a list of all users
+   */
+  fun getAllUsers(): List<User> {
+    return Tasks.await(
+        db.collection(collectionName).get().continueWith { task ->
+          if (task.isSuccessful) {
+            val users = mutableListOf<User>()
+            for (document in task.result!!.documents) {
+              val user = document.toObject(User::class.java)
+              users.add(user!!)
+            }
+            users
+          } else {
+            throw task.exception ?: Exception("Unknown error occurred")
+          }
+        })
+  }
+
+  /**
+   * Adds/edit a user to the database
+   *
+   * @param user the user to add/edit
+   */
+  fun addUser(user: User) {
+    Tasks.await(db.collection(collectionName).document(user.uid).set(user))
+  }
+  /**
+   * Deletes a user from the database
+   *
+   * @param id the id of the user to delete
+   */
+  fun deleteUser(id: String) {
+    Tasks.await(
+        db.collection(collectionName)
+            .document(id)
+            .delete()
+            .addOnSuccessListener { println("DocumentSnapshot successfully deleted! User deleted") }
+            .addOnFailureListener { e -> println("Error deleting document User: $e") })
+  }
+
+  /** Deletes all users from the database */
+  fun deleteAllUsers() {
+    Tasks.await(
+        db.collection(collectionName).get().addOnSuccessListener { querySnapshot ->
+          for (document in querySnapshot) {
+            document.reference.delete()
+          }
+        })
+  }
+
+  /**
+   * Adds multiple users to the database
+   *
+   * @param users the list of users to add
+   */
+  fun addAllUsers(users: List<User>) {
+    for (user in users) {
+      addUser(user)
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
@@ -7,7 +7,8 @@ data class Association(
     val creationDate: String,
     val status: String,
     val members: List<User>,
-    val events: List<Event>
+    val events: List<Event>,
+    val logo: Int
 ) {
-  constructor() : this("", "", "", "", "", listOf(), listOf())
+  constructor() : this("", "", "", "", "", listOf(), listOf(), -1)
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Permission.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Permission.kt
@@ -1,0 +1,11 @@
+package com.github.se.assocify.model.entities
+
+enum class Permission {
+  CREATE_ROLE,
+  ASSIGN_ROLE,
+  EDIT_PERMISSIONS,
+  CREATE_ASSOCIATION,
+  DELETE_ASSOCIATION,
+  CREATE_EVENT,
+  DELETE_EVENT
+}

--- a/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
@@ -1,7 +1,6 @@
 package com.github.se.assocify.model.entities
 
-enum class Role(
-  private var permissions: Set<Permission>) {
+enum class Role(private var permissions: Set<Permission>) {
 
   // The ADMIN role has all permissions
   ADMIN(Permission.entries.toSet()),
@@ -39,9 +38,9 @@ enum class Role(
    *
    * @param role the role to grant
    */
-  fun canGrantRoleTo(user : User, role: Role): Boolean {
-    return this.hasPermission(Permission.ASSIGN_ROLE)
-            && this.hasPermissions(role.getPermissions())
-            && user.role != this
+  fun canGrantRoleTo(user: User, role: Role): Boolean {
+    return this.hasPermission(Permission.ASSIGN_ROLE) &&
+        this.hasPermissions(role.getPermissions()) &&
+        user.role != this
   }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
@@ -1,6 +1,7 @@
 package com.github.se.assocify.model.entities
 
-enum class Role(private var permissions: Set<Permission>) {
+enum class Role(
+  private var permissions: Set<Permission>) {
 
   // The ADMIN role has all permissions
   ADMIN(Permission.entries.toSet()),
@@ -24,32 +25,6 @@ enum class Role(private var permissions: Set<Permission>) {
   private fun hasPermissions(permissions: Set<Permission>): Boolean {
     return this.permissions.containsAll(permissions)
   }
-
-  /**
-   * Adds a permission to the role for fine-grained control
-   *
-   * @param permission the permission to add
-   */
-  private fun addPermission(permission: Permission) {
-    if (hasPermission(Permission.EDIT_PERMISSIONS)) {
-      this.permissions.plus(permission)
-    } else {
-      throw Exception("User does not have permission to add permission")
-    }
-  }
-
-  /**
-   * Removes a permission from the role for fine-grained control
-   *
-   * @param permission the permission to remove
-   */
-  private fun removePermission(permission: Permission) {
-    if (hasPermission(Permission.EDIT_PERMISSIONS)) {
-      this.permissions.minus(permission)
-    } else {
-      throw Exception("User does not have permission to remove permission")
-    }
-  }
   /**
    * Gets the permissions of the role
    *
@@ -66,7 +41,7 @@ enum class Role(private var permissions: Set<Permission>) {
    */
   fun canGrantRoleTo(user : User, role: Role): Boolean {
     return this.hasPermission(Permission.ASSIGN_ROLE)
-            && permissions.containsAll(role.permissions)
+            && this.hasPermissions(role.getPermissions())
             && user.role != this
   }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
@@ -1,5 +1,72 @@
 package com.github.se.assocify.model.entities
 
-data class Role(val name: String) {
-  constructor() : this("")
+enum class Role(private var permissions: Set<Permission>) {
+
+  // The ADMIN role has all permissions
+  ADMIN(Permission.entries.toSet()),
+  MODERATOR(setOf(Permission.ASSIGN_ROLE)),
+  USER(emptySet());
+
+  /**
+   * Checks if the role has the permission
+   *
+   * @param permission the permission to check
+   */
+  private fun hasPermission(permission: Permission): Boolean {
+    return this.permissions.contains(permission)
+  }
+
+  /**
+   * Checks if the role has all the permissions in the set
+   *
+   * @param permissions the set of permissions to check
+   */
+  private fun hasPermissions(permissions: Set<Permission>): Boolean {
+    return this.permissions.containsAll(permissions)
+  }
+
+  /**
+   * Adds a permission to the role for fine-grained control
+   *
+   * @param permission the permission to add
+   */
+  private fun addPermission(permission: Permission) {
+    if (hasPermission(Permission.EDIT_PERMISSIONS)) {
+      this.permissions.plus(permission)
+    } else {
+      throw Exception("User does not have permission to add permission")
+    }
+  }
+
+  /**
+   * Removes a permission from the role for fine-grained control
+   *
+   * @param permission the permission to remove
+   */
+  private fun removePermission(permission: Permission) {
+    if (hasPermission(Permission.EDIT_PERMISSIONS)) {
+      this.permissions.minus(permission)
+    } else {
+      throw Exception("User does not have permission to remove permission")
+    }
+  }
+  /**
+   * Gets the permissions of the role
+   *
+   * @return the permissions of the role
+   */
+  fun getPermissions(): Set<Permission> {
+    return this.permissions.toMutableSet().toSet()
+  }
+
+  /**
+   * Grant a role and ensure the granter can't grant more permissions they have
+   *
+   * @param role the role to grant
+   */
+  fun canGrantRoleTo(user : User, role: Role): Boolean {
+    return this.hasPermission(Permission.ASSIGN_ROLE)
+            && permissions.containsAll(role.permissions)
+            && user.role != this
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/User.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/User.kt
@@ -1,5 +1,34 @@
 package com.github.se.assocify.model.entities
 
-data class User(val uid: String, val name: String, val role: Role) {
-  constructor() : this("", "", Role(""))
+class User(val uid: String,
+                val name: String,
+                role: Role = Role.USER) {
+
+  private var _role: Role
+
+
+  /** Default constructor used for Firebase deserialization */
+  constructor() : this("", "", Role.USER)
+
+  init {
+    _role = role
+  }
+  val role: Role
+    get() = _role
+
+
+  /**
+   * Grants a new role to the user
+   *
+   * @param grantedBy the user granting the role
+   * @param newRole the new role to grant
+   */
+  fun grantRole(grantedBy: User, newRole: Role) {
+    if (grantedBy.role.canGrantRoleTo(this,newRole)) {
+      _role = newRole
+    } else {
+      throw Exception("User does not have permission to grant role")
+    }
+  }
+
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/User.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/User.kt
@@ -1,11 +1,8 @@
 package com.github.se.assocify.model.entities
 
-class User(val uid: String,
-                val name: String,
-                role: Role = Role.USER) {
+class User(val uid: String, val name: String, role: Role = Role.USER) {
 
   private var _role: Role
-
 
   /** Default constructor used for Firebase deserialization */
   constructor() : this("", "", Role.USER)
@@ -13,9 +10,9 @@ class User(val uid: String,
   init {
     _role = role
   }
+
   val role: Role
     get() = _role
-
 
   /**
    * Grants a new role to the user
@@ -24,11 +21,10 @@ class User(val uid: String,
    * @param newRole the new role to grant
    */
   fun grantRole(grantedBy: User, newRole: Role) {
-    if (grantedBy.role.canGrantRoleTo(this,newRole)) {
+    if (grantedBy.role.canGrantRoleTo(this, newRole)) {
       _role = newRole
     } else {
       throw Exception("User does not have permission to grant role")
     }
   }
-
 }

--- a/app/src/test/java/com/github/se/assocify/model/entities/RoleTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/entities/RoleTest.kt
@@ -1,7 +1,5 @@
 package com.github.se.assocify.model.entities
 
 class RoleTest {
-    /**
-     * A big part of it is implemented in UserTest
-     */
+  /** A big part of it is implemented in UserTest */
 }

--- a/app/src/test/java/com/github/se/assocify/model/entities/RoleTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/entities/RoleTest.kt
@@ -1,0 +1,7 @@
+package com.github.se.assocify.model.entities
+
+class RoleTest {
+    /**
+     * A big part of it is implemented in UserTest
+     */
+}

--- a/app/src/test/java/com/github/se/assocify/model/entities/UserTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/entities/UserTest.kt
@@ -1,0 +1,56 @@
+package com.github.se.assocify.model.entities
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+
+class UserTest {
+
+    private var userADMIN: User =User("user1", "User 1", Role.ADMIN)
+    private var otherUser: User = User("user2", "User 2")
+
+
+    @Test
+    fun testGrantRole() {
+        // Try to grant User role to Admin (should fail)
+        assertThrows(Exception::class.java) {
+            userADMIN.grantRole(otherUser, Role.USER)
+        }
+        // Try to grant Moderator role to Admin (should fail)
+        assertThrows(Exception::class.java) {
+            userADMIN.grantRole(otherUser, Role.MODERATOR)
+        }
+        // Try to grant Admin role to Admin (should fail)
+        assertThrows(Exception::class.java) {
+            userADMIN.grantRole(otherUser, Role.ADMIN)
+        }
+
+        // Grant MODERATOR role to otherUser
+        otherUser.grantRole(userADMIN, Role.MODERATOR)
+        assertEquals(Role.MODERATOR, otherUser.role)
+
+        // Grant USER role to otherUser
+        otherUser.grantRole(userADMIN, Role.USER)
+        assertEquals(Role.USER, otherUser.role)
+
+        // Grant ADMIN role to otherUser
+        otherUser.grantRole(userADMIN, Role.ADMIN)
+        assertEquals(Role.ADMIN, otherUser.role)
+
+        // Try to grant User role to otherUser (Now admin) (should fail)
+        assertThrows(Exception::class.java) {
+            otherUser.grantRole(userADMIN, Role.USER)
+        }
+    }
+
+    @Test
+    fun testGrantRoleByUserWithoutPermission() {
+        val userWithoutPermission = User("user3", "User 3", Role.USER)
+
+        // Try to grant MODERATOR role to otherUser (should fail)
+        assertThrows(Exception::class.java) {
+            userWithoutPermission.grantRole(otherUser, Role.MODERATOR)
+        }
+    }
+}

--- a/app/src/test/java/com/github/se/assocify/model/entities/UserTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/entities/UserTest.kt
@@ -2,55 +2,45 @@ package com.github.se.assocify.model.entities
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Before
 import org.junit.Test
 
 class UserTest {
 
-    private var userADMIN: User =User("user1", "User 1", Role.ADMIN)
-    private var otherUser: User = User("user2", "User 2")
+  private var userADMIN: User = User("user1", "User 1", Role.ADMIN)
+  private var otherUser: User = User("user2", "User 2")
 
+  @Test
+  fun testGrantRole() {
+    // Try to grant User role to Admin (should fail)
+    assertThrows(Exception::class.java) { userADMIN.grantRole(otherUser, Role.USER) }
+    // Try to grant Moderator role to Admin (should fail)
+    assertThrows(Exception::class.java) { userADMIN.grantRole(otherUser, Role.MODERATOR) }
+    // Try to grant Admin role to Admin (should fail)
+    assertThrows(Exception::class.java) { userADMIN.grantRole(otherUser, Role.ADMIN) }
 
-    @Test
-    fun testGrantRole() {
-        // Try to grant User role to Admin (should fail)
-        assertThrows(Exception::class.java) {
-            userADMIN.grantRole(otherUser, Role.USER)
-        }
-        // Try to grant Moderator role to Admin (should fail)
-        assertThrows(Exception::class.java) {
-            userADMIN.grantRole(otherUser, Role.MODERATOR)
-        }
-        // Try to grant Admin role to Admin (should fail)
-        assertThrows(Exception::class.java) {
-            userADMIN.grantRole(otherUser, Role.ADMIN)
-        }
+    // Grant MODERATOR role to otherUser
+    otherUser.grantRole(userADMIN, Role.MODERATOR)
+    assertEquals(Role.MODERATOR, otherUser.role)
 
-        // Grant MODERATOR role to otherUser
-        otherUser.grantRole(userADMIN, Role.MODERATOR)
-        assertEquals(Role.MODERATOR, otherUser.role)
+    // Grant USER role to otherUser
+    otherUser.grantRole(userADMIN, Role.USER)
+    assertEquals(Role.USER, otherUser.role)
 
-        // Grant USER role to otherUser
-        otherUser.grantRole(userADMIN, Role.USER)
-        assertEquals(Role.USER, otherUser.role)
+    // Grant ADMIN role to otherUser
+    otherUser.grantRole(userADMIN, Role.ADMIN)
+    assertEquals(Role.ADMIN, otherUser.role)
 
-        // Grant ADMIN role to otherUser
-        otherUser.grantRole(userADMIN, Role.ADMIN)
-        assertEquals(Role.ADMIN, otherUser.role)
+    // Try to grant User role to otherUser (Now admin) (should fail)
+    assertThrows(Exception::class.java) { otherUser.grantRole(userADMIN, Role.USER) }
+  }
 
-        // Try to grant User role to otherUser (Now admin) (should fail)
-        assertThrows(Exception::class.java) {
-            otherUser.grantRole(userADMIN, Role.USER)
-        }
+  @Test
+  fun testGrantRoleByUserWithoutPermission() {
+    val userWithoutPermission = User("user3", "User 3", Role.USER)
+
+    // Try to grant MODERATOR role to otherUser (should fail)
+    assertThrows(Exception::class.java) {
+      userWithoutPermission.grantRole(otherUser, Role.MODERATOR)
     }
-
-    @Test
-    fun testGrantRoleByUserWithoutPermission() {
-        val userWithoutPermission = User("user3", "User 3", Role.USER)
-
-        // Try to grant MODERATOR role to otherUser (should fail)
-        assertThrows(Exception::class.java) {
-            userWithoutPermission.grantRole(otherUser, Role.MODERATOR)
-        }
-    }
+  }
 }


### PR DESCRIPTION
- [x]  Permissions enum class
- [x] Roles enum class integration with permissions
- [x] Roles basic functions : getPermissions, has permission/s
- [x] Role function canGrantRoleTo :  return a boolean if this can grant a role to another user respecting policy
- [x] User basic structure : private property _role and role is read-only from outside
- [x] User grant role :this user can be grant a role by a user respecting the policy


Basic Security Policy now : User can grant a role to another user as long :
-  The granted permission set is strictly inferior to the granter permission set and the granter has the permission "ASSIGN_ROLE"

Goal : gather all access control in on place. I chose the Role enum class for pratice purpose but it can be changed