### PR TITLE
UI - Create new association page

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.assocify.screens
 
-import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -10,41 +9,45 @@ import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
 import com.github.se.assocify.ui.screens.createAsso.CreateAssoScreen
 import com.github.se.assocify.ui.screens.createAsso.CreateAssoViewmodel
-import com.github.se.assocify.ui.screens.treasury.TreasuryScreen
-import io.mockk.every
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class CreateAssoScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private val bigList = listOf(
-        User("1", "jean", Role("com")), User("2", "roger", Role("tres")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("2", "roger", Role("tres")),
-        User("2", "roger", Role("tres")),
-        User("2", "roger", Role("tres")), User("2", "roger", Role("tres")),
-        User("2", "roger", Role("tres")),
-        User("2", "roger", Role("tres"))
-    )
-    private val smallList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")))
+  private val bigList =
+      listOf(
+          User("1", "jean", Role("com")),
+          User("2", "roger", Role("tres")),
+          User("1", "jean", Role("com")),
+          User("1", "jean", Role("com")),
+          User("1", "jean", Role("com")),
+          User("1", "jean", Role("com")),
+          User("1", "jean", Role("com")),
+          User("1", "jean", Role("com")),
+          User("2", "roger", Role("tres")),
+          User("2", "roger", Role("tres")),
+          User("2", "roger", Role("tres")),
+          User("2", "roger", Role("tres")),
+          User("2", "roger", Role("tres")),
+          User("2", "roger", Role("tres")))
+  private val smallList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")))
 
-    private val bigView = CreateAssoViewmodel(bigList)
-    private val smallView = CreateAssoViewmodel(smallList)
+  private val bigView = CreateAssoViewmodel(bigList)
+  private val smallView = CreateAssoViewmodel(smallList)
 
-    @Test
-    fun displaySmall() {
-        composeTestRule.setContent { CreateAssoScreen(smallView) }
-        with(composeTestRule) {
-            onNodeWithTag("createAssoScreen").assertIsDisplayed()
-            onNodeWithTag("TopAppBar").assertIsDisplayed()
-            onNodeWithTag("logo").assertIsDisplayed()
-            onNodeWithTag("name").assertIsDisplayed()
-            onNodeWithTag("MemberList").assertIsDisplayed()
-            onAllNodesWithTag("MemberListItem").assertCountEquals(2)
-            onNodeWithTag("addMember").assertIsDisplayed()
-            onNodeWithTag("create").assertIsDisplayed()
-        }
-
+  @Test
+  fun displaySmall() {
+    composeTestRule.setContent { CreateAssoScreen(smallView) }
+    with(composeTestRule) {
+      onNodeWithTag("createAssoScreen").assertIsDisplayed()
+      onNodeWithTag("TopAppBar").assertIsDisplayed()
+      onNodeWithTag("logo").assertIsDisplayed()
+      onNodeWithTag("name").assertIsDisplayed()
+      onNodeWithTag("MemberList").assertIsDisplayed()
+      onAllNodesWithTag("MemberListItem").assertCountEquals(2)
+      onNodeWithTag("addMember").assertIsDisplayed()
+      onNodeWithTag("create").assertIsDisplayed()
     }
+  }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
@@ -1,0 +1,5 @@
+package com.github.se.assocify.screens
+
+class CreateAssoScreenTest {
+
+}

--- a/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
@@ -1,5 +1,50 @@
 package com.github.se.assocify.screens
 
-class CreateAssoScreenTest {
+import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import com.github.se.assocify.model.entities.Role
+import com.github.se.assocify.model.entities.User
+import com.github.se.assocify.ui.screens.createAsso.CreateAssoScreen
+import com.github.se.assocify.ui.screens.createAsso.CreateAssoViewmodel
+import com.github.se.assocify.ui.screens.treasury.TreasuryScreen
+import io.mockk.every
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 
+class CreateAssoScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val bigList = listOf(
+        User("1", "jean", Role("com")), User("2", "roger", Role("tres")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("2", "roger", Role("tres")),
+        User("2", "roger", Role("tres")),
+        User("2", "roger", Role("tres")), User("2", "roger", Role("tres")),
+        User("2", "roger", Role("tres")),
+        User("2", "roger", Role("tres"))
+    )
+    private val smallList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")))
+
+    private val bigView = CreateAssoViewmodel(bigList)
+    private val smallView = CreateAssoViewmodel(smallList)
+
+    @Test
+    fun displaySmall() {
+        composeTestRule.setContent { CreateAssoScreen(smallView) }
+        with(composeTestRule) {
+            onNodeWithTag("createAssoScreen").assertIsDisplayed()
+            onNodeWithTag("TopAppBar").assertIsDisplayed()
+            onNodeWithTag("logo").assertIsDisplayed()
+            onNodeWithTag("name").assertIsDisplayed()
+            onNodeWithTag("MemberList").assertIsDisplayed()
+            onAllNodesWithTag("MemberListItem").assertCountEquals(2)
+            onNodeWithTag("addMember").assertIsDisplayed()
+            onNodeWithTag("create").assertIsDisplayed()
+        }
+
+    }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
@@ -1,6 +1,5 @@
 package com.github.se.assocify.ui.screens.createAsso
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -20,8 +20,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.OutlinedTextField
@@ -36,8 +34,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.github.se.assocify.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,7 +61,7 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
             },
             title = { Text(text = "Create your association") })
       },
-      contentWindowInsets = WindowInsets(50.dp, 10.dp, 50.dp, 20.dp)) { innerPadding ->
+      contentWindowInsets = WindowInsets(20.dp, 10.dp, 20.dp, 20.dp)) { innerPadding ->
         Column(
             modifier = Modifier.fillMaxSize().padding(innerPadding),
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -77,30 +78,26 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
                     onClick = {
                       /* TODO : can add association logo */
                     }) {
-                      Icon(Icons.Default.Person, contentDescription = "Logo")
+                      Icon(
+                          painter = painterResource(id = R.drawable.landscape),
+                          contentDescription = "Logo")
                     }
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
-                    label = { Text("Name") },
+                    label = { Text("Association Name") },
                     modifier = Modifier.fillMaxWidth().testTag("name"))
               }
 
           LazyColumn(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .weight(1f)
-                      .background(MaterialTheme.colorScheme.primaryContainer)
-                      .testTag("MemberList"),
+              modifier = Modifier.fillMaxWidth().weight(1f).testTag("MemberList"),
               verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
               horizontalAlignment = Alignment.CenterHorizontally) {
                 state.forEach { member ->
                   item {
                     ListItem(
-                        modifier = Modifier.testTag("MemberListItem"),
-                        colors =
-                            ListItemDefaults.colors(
-                                containerColor = MaterialTheme.colorScheme.primaryContainer),
+                        modifier =
+                            Modifier.clip(RoundedCornerShape(10.dp)).testTag("MemberListItem"),
                         headlineContent = { Text(member.name) },
                         overlineContent = { Text(member.role.name) },
                         leadingContent = {
@@ -115,11 +112,10 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
                               }
                         },
                     )
-                    HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
+                    HorizontalDivider()
                   }
                 }
               }
-          //        Spacer(Modifier.weight(0.5f))
           Column(
               horizontalAlignment = Alignment.CenterHorizontally,
               modifier = Modifier.fillMaxWidth()) {
@@ -135,7 +131,6 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
                       Text("Create")
                     }
               }
-          //        Spacer(Modifier.weight(0.1f))
         }
       }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
@@ -72,9 +72,7 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
               verticalAlignment = Alignment.CenterVertically,
               modifier = Modifier.fillMaxWidth()) {
                 OutlinedIconButton(
-                    modifier =
-                        Modifier.padding(top = 8.dp)
-                            .testTag("logo") /*.background(MaterialTheme.colorScheme.primary)*/,
+                    modifier = Modifier.padding(top = 8.dp).testTag("logo"),
                     onClick = {
                       /* TODO : can add association logo */
                     }) {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
@@ -55,7 +55,7 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
             modifier = Modifier.fillMaxWidth().testTag("TopAppBar"),
             navigationIcon = {
               IconButton(onClick = { /*TODO : go back to previous screen*/}) {
-                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
               }
             },
             title = { Text(text = "Create your association") })

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,14 +14,12 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -30,9 +27,9 @@ import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,17 +43,18 @@ import com.github.se.assocify.model.entities.User
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun createAssoScreen() {
-  // should maybe be in viewmodel or something
-    val bigList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("2", "roger", Role("tres")),User("2", "roger", Role("tres")),User("2", "roger", Role("tres")), User("2", "roger", Role("tres")),User("2", "roger", Role("tres")),User("2", "roger", Role("tres")))
-  val smallList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")))
-    var memberList by remember { mutableStateOf(bigList) }
-  var name by remember { mutableStateOf("") }
+fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf())) {
+
+    val state by viewmodel.uiState.collectAsState()
+
+    // should also be in viewmodel probably
+    var name by remember { mutableStateOf("") }
 
   Scaffold(
+        modifier = Modifier.testTag("createAssoScreen"),
       topBar = {
           TopAppBar(
-              modifier = Modifier.fillMaxWidth(),
+              modifier = Modifier.fillMaxWidth().testTag("TopAppBar"),
               navigationIcon = {
                   IconButton(onClick = { /*TODO : go back to previous screen*/ }) {
                       Icon(Icons.Default.ArrowBack, contentDescription = "Back")
@@ -82,7 +80,7 @@ fun createAssoScreen() {
             modifier = Modifier.fillMaxWidth()
         ) {
             OutlinedIconButton(
-                modifier = Modifier.padding(top = 8.dp)/*.background(MaterialTheme.colorScheme.primary)*/,
+                modifier = Modifier.padding(top = 8.dp).testTag("logo")/*.background(MaterialTheme.colorScheme.primary)*/,
                 onClick = {
                     /* TODO : can add association logo */
                 }) {
@@ -92,7 +90,7 @@ fun createAssoScreen() {
                 value = name,
                 onValueChange = { name = it },
                 label = { Text("Name") },
-                modifier = Modifier.fillMaxWidth()/*.background(MaterialTheme.colorScheme.secondary)*/
+                modifier = Modifier.fillMaxWidth().testTag("name")
             )
         }
 
@@ -104,7 +102,7 @@ fun createAssoScreen() {
                 .testTag("MemberList"),
             verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
             horizontalAlignment = Alignment.CenterHorizontally) {
-            memberList.forEach { member ->
+            state.forEach { member ->
                 item {
                     ListItem(
                         modifier =
@@ -131,11 +129,12 @@ fun createAssoScreen() {
 //        Spacer(Modifier.weight(0.5f))
         Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
             OutlinedButton(
-                onClick = { /*TODO : add members to list*/}, modifier = Modifier.fillMaxWidth()) {
+                onClick = { /*TODO : add members to list*/},
+                modifier = Modifier.fillMaxWidth().testTag("addMember")) {
                 Icon(Icons.Default.Add, contentDescription = "Add members")
                 Text("Add members")
             }
-            Button(onClick = { /*TODO : add asso to DB */}, modifier = Modifier.fillMaxWidth()) { Text("Create") }
+            Button(onClick = { /*TODO : add asso to DB */}, modifier = Modifier.fillMaxWidth().testTag("create")) { Text("Create") }
         }
 //        Spacer(Modifier.weight(0.1f))
     }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
@@ -38,105 +38,104 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.se.assocify.model.entities.Role
-import com.github.se.assocify.model.entities.User
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf())) {
 
-    val state by viewmodel.uiState.collectAsState()
+  val state by viewmodel.uiState.collectAsState()
 
-    // should also be in viewmodel probably
-    var name by remember { mutableStateOf("") }
+  // should also be in viewmodel probably
+  var name by remember { mutableStateOf("") }
 
   Scaffold(
-        modifier = Modifier.testTag("createAssoScreen"),
+      modifier = Modifier.testTag("createAssoScreen"),
       topBar = {
-          TopAppBar(
-              modifier = Modifier.fillMaxWidth().testTag("TopAppBar"),
-              navigationIcon = {
-                  IconButton(onClick = { /*TODO : go back to previous screen*/ }) {
-                      Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                  }
-              },
-              title = {
-                  Text(text = "Create your association")
+        TopAppBar(
+            modifier = Modifier.fillMaxWidth().testTag("TopAppBar"),
+            navigationIcon = {
+              IconButton(onClick = { /*TODO : go back to previous screen*/}) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
               }
-          )
+            },
+            title = { Text(text = "Create your association") })
       },
-      contentWindowInsets = WindowInsets(50.dp, 10.dp, 50.dp, 20.dp)
-  ) { innerPadding ->
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(15.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+      contentWindowInsets = WindowInsets(50.dp, 10.dp, 50.dp, 20.dp)) { innerPadding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(innerPadding),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            OutlinedIconButton(
-                modifier = Modifier.padding(top = 8.dp).testTag("logo")/*.background(MaterialTheme.colorScheme.primary)*/,
-                onClick = {
-                    /* TODO : can add association logo */
-                }) {
-                Icon(Icons.Default.Person, contentDescription = "Logo")
-            }
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Name") },
-                modifier = Modifier.fillMaxWidth().testTag("name")
-            )
-        }
+          Row(
+              horizontalArrangement = Arrangement.spacedBy(15.dp),
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.fillMaxWidth()) {
+                OutlinedIconButton(
+                    modifier =
+                        Modifier.padding(top = 8.dp)
+                            .testTag("logo") /*.background(MaterialTheme.colorScheme.primary)*/,
+                    onClick = {
+                      /* TODO : can add association logo */
+                    }) {
+                      Icon(Icons.Default.Person, contentDescription = "Logo")
+                    }
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    modifier = Modifier.fillMaxWidth().testTag("name"))
+              }
 
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .testTag("MemberList"),
-            verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
-            horizontalAlignment = Alignment.CenterHorizontally) {
-            state.forEach { member ->
-                item {
+          LazyColumn(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .weight(1f)
+                      .background(MaterialTheme.colorScheme.primaryContainer)
+                      .testTag("MemberList"),
+              verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                state.forEach { member ->
+                  item {
                     ListItem(
-                        modifier =
-                        Modifier
-                            .testTag("MemberListItem")
-                        ,
-                        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                        modifier = Modifier.testTag("MemberListItem"),
+                        colors =
+                            ListItemDefaults.colors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer),
                         headlineContent = { Text(member.name) },
                         overlineContent = { Text(member.role.name) },
-                        leadingContent = { Icon(Icons.Default.Person, contentDescription = "Person") },
+                        leadingContent = {
+                          Icon(Icons.Default.Person, contentDescription = "Person")
+                        },
                         trailingContent = {
-                            IconButton(
-                                onClick = {
-                                    /*TODO : edit member from list */
-                                }) {
+                          IconButton(
+                              onClick = {
+                                /*TODO : edit member from list */
+                              }) {
                                 Icon(Icons.Default.Edit, contentDescription = "Edit")
-                            }
+                              }
                         },
                     )
                     HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
+                  }
                 }
-            }
+              }
+          //        Spacer(Modifier.weight(0.5f))
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = { /*TODO : add members to list*/},
+                    modifier = Modifier.fillMaxWidth().testTag("addMember")) {
+                      Icon(Icons.Default.Add, contentDescription = "Add members")
+                      Text("Add members")
+                    }
+                Button(
+                    onClick = { /*TODO : add asso to DB */},
+                    modifier = Modifier.fillMaxWidth().testTag("create")) {
+                      Text("Create")
+                    }
+              }
+          //        Spacer(Modifier.weight(0.1f))
         }
-//        Spacer(Modifier.weight(0.5f))
-        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
-            OutlinedButton(
-                onClick = { /*TODO : add members to list*/},
-                modifier = Modifier.fillMaxWidth().testTag("addMember")) {
-                Icon(Icons.Default.Add, contentDescription = "Add members")
-                Text("Add members")
-            }
-            Button(onClick = { /*TODO : add asso to DB */}, modifier = Modifier.fillMaxWidth().testTag("create")) { Text("Create") }
-        }
-//        Spacer(Modifier.weight(0.1f))
-    }
-  }
+      }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoViewmodel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoViewmodel.kt
@@ -1,0 +1,13 @@
+package com.github.se.assocify.ui.screens.createAsso
+
+import androidx.lifecycle.ViewModel
+import com.github.se.assocify.model.entities.Role
+import com.github.se.assocify.model.entities.User
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class CreateAssoViewmodel(userList: List<User>) : ViewModel() {
+    private val _uiState = MutableStateFlow(userList)
+    val uiState: StateFlow<List<User>> = _uiState
+
+}

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoViewmodel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoViewmodel.kt
@@ -1,13 +1,11 @@
 package com.github.se.assocify.ui.screens.createAsso
 
 import androidx.lifecycle.ViewModel
-import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class CreateAssoViewmodel(userList: List<User>) : ViewModel() {
-    private val _uiState = MutableStateFlow(userList)
-    val uiState: StateFlow<List<User>> = _uiState
-
+  private val _uiState = MutableStateFlow(userList)
+  val uiState: StateFlow<List<User>> = _uiState
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/createAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/createAssoScreen.kt
@@ -4,24 +4,34 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,75 +41,103 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun createAssoScreen() {
-// should maybe be in viewmodel or something
-  var memberList by remember { mutableStateOf(emptyList<User>()) }
+  // should maybe be in viewmodel or something
+    val bigList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("1", "jean", Role("com")), User("2", "roger", Role("tres")),User("2", "roger", Role("tres")),User("2", "roger", Role("tres")), User("2", "roger", Role("tres")),User("2", "roger", Role("tres")),User("2", "roger", Role("tres")))
+  val smallList = listOf(User("1", "jean", Role("com")), User("2", "roger", Role("tres")))
+    var memberList by remember { mutableStateOf(bigList) }
   var name by remember { mutableStateOf("") }
 
   Scaffold(
       topBar = {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-          Text(text = "Create your association !")
-          Row(
+          TopAppBar(
               modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.SpaceBetween,
-              verticalAlignment = Alignment.CenterVertically) {
-                IconButton(
-                    onClick = {
-                      /* TODO : can add association logo */
-                    }) {
-                      Icon(Icons.Default.Person, contentDescription = "Logo")
-                    }
-                TextField(
-                    value = name,
-                    onValueChange = { name = it },
-                    label = { Text("Name") },
-                )
+              navigationIcon = {
+                  IconButton(onClick = { /*TODO : go back to previous screen*/ }) {
+                      Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                  }
+              },
+              title = {
+                  Text(text = "Create your association")
               }
-        }
+          )
       },
-      bottomBar = {
-        OutlinedButton(
-            onClick = { /*TODO : add members to list*/}, modifier = Modifier.fillMaxWidth()) {
-              Icon(Icons.Default.Add, contentDescription = "Add members")
-              Text("Add members")
-            }
-        Button(onClick = { /*TODO : add asso to DB */}) { Text("Create") }
-      },
+      contentWindowInsets = WindowInsets(50.dp, 10.dp, 50.dp, 20.dp)
   ) { innerPadding ->
-    LazyColumn(
-        modifier = Modifier.testTag("TodoList").padding(innerPadding),
-        verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
-        horizontalAlignment = Alignment.CenterHorizontally) {
-          memberList.forEach { member ->
-            item {
-              ListItem(
-                  modifier =
-                      Modifier.testTag("MemberListItem")
-                          .padding(start = 16.dp, end = 16.dp)
-                          .background(MaterialTheme.colorScheme.background),
-                  headlineContent = { Text(member.name) },
-                  overlineContent = { Text(member.role.toString()) },
-                  leadingContent = { Icon(Icons.Default.Person, contentDescription = "Person") },
-                  trailingContent = {
-                    IconButton(
-                        onClick = {
-                          /*TODO : edit member from list */
-                        }) {
-                          Icon(Icons.Default.Edit, contentDescription = "Edit")
-                        }
-                  },
-              )
-              HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            OutlinedIconButton(
+                modifier = Modifier.padding(top = 8.dp)/*.background(MaterialTheme.colorScheme.primary)*/,
+                onClick = {
+                    /* TODO : can add association logo */
+                }) {
+                Icon(Icons.Default.Person, contentDescription = "Logo")
             }
-          }
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                modifier = Modifier.fillMaxWidth()/*.background(MaterialTheme.colorScheme.secondary)*/
+            )
         }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .testTag("MemberList"),
+            verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+            memberList.forEach { member ->
+                item {
+                    ListItem(
+                        modifier =
+                        Modifier
+                            .testTag("MemberListItem")
+                        ,
+                        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                        headlineContent = { Text(member.name) },
+                        overlineContent = { Text(member.role.name) },
+                        leadingContent = { Icon(Icons.Default.Person, contentDescription = "Person") },
+                        trailingContent = {
+                            IconButton(
+                                onClick = {
+                                    /*TODO : edit member from list */
+                                }) {
+                                Icon(Icons.Default.Edit, contentDescription = "Edit")
+                            }
+                        },
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
+                }
+            }
+        }
+//        Spacer(Modifier.weight(0.5f))
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(
+                onClick = { /*TODO : add members to list*/}, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.Add, contentDescription = "Add members")
+                Text("Add members")
+            }
+            Button(onClick = { /*TODO : add asso to DB */}, modifier = Modifier.fillMaxWidth()) { Text("Create") }
+        }
+//        Spacer(Modifier.weight(0.1f))
+    }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/createAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/createAssoScreen.kt
@@ -1,0 +1,105 @@
+package com.github.se.assocify.ui.screens.createAsso
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.se.assocify.model.entities.User
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun createAssoScreen() {
+// should maybe be in viewmodel or something
+  var memberList by remember { mutableStateOf(emptyList<User>()) }
+  var name by remember { mutableStateOf("") }
+
+  Scaffold(
+      topBar = {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          Text(text = "Create your association !")
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = {
+                      /* TODO : can add association logo */
+                    }) {
+                      Icon(Icons.Default.Person, contentDescription = "Logo")
+                    }
+                TextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                )
+              }
+        }
+      },
+      bottomBar = {
+        OutlinedButton(
+            onClick = { /*TODO : add members to list*/}, modifier = Modifier.fillMaxWidth()) {
+              Icon(Icons.Default.Add, contentDescription = "Add members")
+              Text("Add members")
+            }
+        Button(onClick = { /*TODO : add asso to DB */}) { Text("Create") }
+      },
+  ) { innerPadding ->
+    LazyColumn(
+        modifier = Modifier.testTag("TodoList").padding(innerPadding),
+        verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
+        horizontalAlignment = Alignment.CenterHorizontally) {
+          memberList.forEach { member ->
+            item {
+              ListItem(
+                  modifier =
+                      Modifier.testTag("MemberListItem")
+                          .padding(start = 16.dp, end = 16.dp)
+                          .background(MaterialTheme.colorScheme.background),
+                  headlineContent = { Text(member.name) },
+                  overlineContent = { Text(member.role.toString()) },
+                  leadingContent = { Icon(Icons.Default.Person, contentDescription = "Person") },
+                  trailingContent = {
+                    IconButton(
+                        onClick = {
+                          /*TODO : edit member from list */
+                        }) {
+                          Icon(Icons.Default.Edit, contentDescription = "Edit")
+                        }
+                  },
+              )
+              HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
+            }
+          }
+        }
+  }
+}

--- a/app/src/main/res/drawable/landscape.xml
+++ b/app/src/main/res/drawable/landscape.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m40,720 l240,-320 180,240h300L560,374 460,506l-50,-66 150,-200 360,480L40,720ZM561,640ZM200,640h160l-80,-107 -80,107ZM200,640h160,-160Z"/>
+</vector>


### PR DESCRIPTION
Connected to user story #32 and issue #22 
The UI of the "create a new association" page, where a committee member of an association can register it on the app : with the association's name, logo, and members. Members are users already registered in the app, with their name and picture. They will be assigned a role within the association which will give them different permissions on the app.