### PR TITLE
Add basic Entity methods and tests for maintanability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,7 +110,9 @@ dependencies {
     implementation("com.google.android.gms:play-services-auth:21.0.0")
     implementation("com.google.firebase:firebase-auth-ktx:22.3.1")
     implementation("com.google.firebase:firebase-database-ktx:20.3.1")
+    // Junit
     testImplementation("junit:junit:4.13.2")
+
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.4")

--- a/app/src/androidTest/java/com/github/se/assocify/AssociationAPITest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/AssociationAPITest.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.entities.Association
 import com.google.android.gms.tasks.Tasks
@@ -10,9 +11,11 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 
+@RunWith(AndroidJUnit4::class)
 class AssociationAPITest {
 
   @Mock private lateinit var db: FirebaseFirestore
@@ -38,7 +41,7 @@ class AssociationAPITest {
     Mockito.`when`(documentSnapshot.toObject(Association::class.java)).thenReturn(asso)
     Mockito.`when`(documentReference.get()).thenReturn(Tasks.forResult(documentSnapshot))
 
-    val task = Tasks.forResult(documentSnapshot)
+    Tasks.forResult(documentSnapshot)
     Mockito.`when`(db.collection(Mockito.any())).thenReturn(Mockito.mock())
     Mockito.`when`(db.collection(Mockito.any()).document(Mockito.any()))
         .thenReturn(documentReference)

--- a/app/src/androidTest/java/com/github/se/assocify/AssociationUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/AssociationUtilsTest.kt
@@ -16,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AssociationUtilsTest {

--- a/app/src/androidTest/java/com/github/se/assocify/AssociationUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/AssociationUtilsTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.associations.AssociationUtils
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.entities.Association
@@ -13,9 +14,11 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
 
+@RunWith(AndroidJUnit4::class)
 class AssociationUtilsTest {
   private lateinit var db: FirebaseFirestore
   private lateinit var assoApi: AssociationAPI
@@ -24,7 +27,7 @@ class AssociationUtilsTest {
   private val collectionReference = mock(CollectionReference::class.java)
   private val president = User("testId", "Carlo", Role("president"))
   private val newUser = User()
-  val oldAsso =
+  private val oldAsso =
       Association(
           "aId",
           "cassify",
@@ -33,7 +36,7 @@ class AssociationUtilsTest {
           "active",
           listOf(president),
           emptyList())
-  val oldAssoUpdated =
+  private val oldAssoUpdated =
       Association(
           "aId",
           "cassify",
@@ -42,7 +45,7 @@ class AssociationUtilsTest {
           "active",
           listOf(president, newUser),
           emptyList())
-  val oldAssoReviewed =
+  private val oldAssoReviewed =
       Association(
           "aId",
           "cassify",
@@ -51,15 +54,15 @@ class AssociationUtilsTest {
           "active",
           listOf(president, User("", "", Role("newRole"))),
           emptyList())
-  val u1 = User("a", "1", Role("president"))
-  val u2 = User("b", "2", Role("user"))
-  val u3 = User("c", "3", Role("user"))
-  val u4 = User("d", "4", Role("pending"))
-  val u5 = User("e", "5", Role("pending"))
-  val e1 = Event("s1", "e1", emptyList(), emptyList())
-  val e2 = Event("s2", "e2", emptyList(), emptyList())
-  val e3 = Event("s3", "e3", emptyList(), emptyList())
-  val getterAsso =
+  private val u1 = User("a", "1", Role("president"))
+  private val u2 = User("b", "2", Role("user"))
+  private val u3 = User("c", "3", Role("user"))
+  private val u4 = User("d", "4", Role("pending"))
+  private val u5 = User("e", "5", Role("pending"))
+  private val e1 = Event("s1", "e1", "", "", "", emptyList(), emptyList())
+  private val e2 = Event("s2", "e2", "", "", "", emptyList(), emptyList())
+  private val e3 = Event("s3", "e3", "", "", "", emptyList(), emptyList())
+  private val getterAsso =
       Association(
           "getId",
           "gettify",
@@ -91,7 +94,7 @@ class AssociationUtilsTest {
     Mockito.`when`(documentSnapshot.toObject(Association::class.java)).thenReturn(oldAssoUpdated)
     Mockito.`when`(documentReference.get()).thenReturn(Tasks.forResult(documentSnapshot))
 
-    Mockito.`when`(db.collection(Mockito.any())).thenReturn(Mockito.mock())
+    Mockito.`when`(db.collection(Mockito.any())).thenReturn(mock())
     Mockito.`when`(db.collection(Mockito.any()).document(Mockito.any()))
         .thenReturn(documentReference)
     val assocUtilsUpdated = AssociationUtils(president, oldAssoUpdated.uid, assoApi)
@@ -114,7 +117,7 @@ class AssociationUtilsTest {
     Mockito.`when`(documentSnapshot.toObject(Association::class.java)).thenReturn(oldAsso)
     Mockito.`when`(documentReference.get()).thenReturn(Tasks.forResult(documentSnapshot))
 
-    Mockito.`when`(db.collection(Mockito.any())).thenReturn(Mockito.mock())
+    Mockito.`when`(db.collection(Mockito.any())).thenReturn(mock())
     Mockito.`when`(db.collection(Mockito.any()).document(Mockito.any()))
         .thenReturn(documentReference)
     val newUserUtils = AssociationUtils(newUser, oldAsso.uid, assoApi)
@@ -159,7 +162,7 @@ class AssociationUtilsTest {
     Mockito.`when`(documentSnapshot.toObject(Association::class.java)).thenReturn(getterAsso)
     Mockito.`when`(documentReference.get()).thenReturn(Tasks.forResult(documentSnapshot))
 
-    Mockito.`when`(db.collection(Mockito.any())).thenReturn(Mockito.mock())
+    Mockito.`when`(db.collection(Mockito.any())).thenReturn(mock())
     Mockito.`when`(db.collection(Mockito.any()).document(Mockito.any()))
         .thenReturn(documentReference)
 

--- a/app/src/androidTest/java/com/github/se/assocify/FirebaseTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/FirebaseTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.database.FirebaseApi
 import com.google.android.gms.tasks.Tasks
@@ -9,9 +10,11 @@ import com.google.firebase.firestore.FirebaseFirestore
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 
+@RunWith(AndroidJUnit4::class)
 class FirebaseTest {
 
   @Mock private lateinit var db: FirebaseFirestore
@@ -19,7 +22,7 @@ class FirebaseTest {
   private lateinit var assoAPI: FirebaseApi
   private val collectionReference = Mockito.mock(CollectionReference::class.java)
 
-  val uid = "testId"
+  private val uid = "testId"
 
   @Before
   fun setup() {
@@ -45,7 +48,7 @@ class FirebaseTest {
         .thenReturn(documentReference)
     Mockito.`when`(db.collection(Mockito.any()).document(Mockito.any()).delete())
         .thenReturn(Tasks.forResult(null))
-    val result = Tasks.await(assoAPI.delete(uid))
+    Tasks.await(assoAPI.delete(uid))
 
     Mockito.verify(db).collection(assoAPI.collectionName)
     Mockito.verify(db.collection(assoAPI.collectionName)).document(uid)

--- a/app/src/androidTest/java/com/github/se/assocify/UserAPITest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/UserAPITest.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
@@ -11,9 +12,11 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 
+@RunWith(AndroidJUnit4::class)
 class UserAPITest {
 
   @Mock private lateinit var db: FirebaseFirestore

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -52,7 +52,7 @@ class DisplayOrganizationScreenTest(semanticsProvider: SemanticsNodeInteractions
 @RunWith(AndroidJUnit4::class)
 class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
-  val registeredAssociation = listOf("CLIC", "GAME*")
+  private val registeredAssociation = listOf("CLIC", "GAME*")
 
   /** This test checks if the "Create new organization" button is displayed */
   @Test

--- a/app/src/main/java/com/github/se/assocify/model/associations/AssociationUtils.kt
+++ b/app/src/main/java/com/github/se/assocify/model/associations/AssociationUtils.kt
@@ -17,7 +17,7 @@ class AssociationUtils(
     update()
   }
 
-  fun update() {
+  private fun update() {
     if (assocId != "") _associationState = associationDatabase.getAssociation(assocId)
   }
 
@@ -129,7 +129,7 @@ class AssociationUtils(
     _associationState = null
   }
 
-  fun getAllAssociations(): List<Association> {
+  private fun getAllAssociations(): List<Association> {
     if (_associationState == null) return emptyList()
     return associationDatabase.getAssociations()
   }

--- a/app/src/main/java/com/github/se/assocify/model/associations/AssociationUtils.kt
+++ b/app/src/main/java/com/github/se/assocify/model/associations/AssociationUtils.kt
@@ -30,7 +30,7 @@ class AssociationUtils(
     if (_associationState == null) {
       return emptyList()
     }
-    return _associationState!!.members.filter { x -> x.role == Role("pending") }
+    return _associationState!!.getMembers().filter { x -> x.getRole() == Role("pending") }
   }
 
   fun getRecordedUsers(): List<User> {
@@ -38,7 +38,7 @@ class AssociationUtils(
     if (_associationState == null) {
       return emptyList()
     }
-    return _associationState!!.members.filter { x -> x.role != Role("pending") }
+    return _associationState!!.getMembers().filter { x -> x.getRole() != Role("pending") }
   }
 
   fun getAllUsers(): List<User> {
@@ -46,46 +46,46 @@ class AssociationUtils(
     if (_associationState == null) {
       return emptyList()
     }
-    return _associationState!!.members
+    return _associationState!!.getMembers()
   }
 
   fun getAssociationName(): String {
     if (_associationState == null) return ""
-    return _associationState!!.name
+    return _associationState!!.getName()
   }
 
   fun getAssociationDescription(): String {
     if (_associationState == null) return ""
-    return _associationState!!.description
+    return _associationState!!.getDescription()
   }
 
   fun getCreationDate(): String {
     if (_associationState == null) return ""
-    return _associationState!!.creationDate
+    return _associationState!!.getCreationDate()
   }
 
   fun getEvents(): List<Event> {
     if (_associationState == null) return emptyList()
-    return _associationState!!.events
+    return _associationState!!.getEvents()
   }
 
   fun acceptNewUser(uid: String, role: String) {
     if (_associationState != null &&
-        (user.role == Role("president") || user.role == Role("co-president"))) {
+        (user.getRole() == Role("president") || user.getRole() == Role("co-president"))) {
       val userList = getPendingUsers().filter { u -> u.uid == uid }
       if (userList.isEmpty()) return
       val user = userList[0]
-      val updatedUser = User(uid, user.name, Role(role))
+      val updatedUser = User(uid, user.getName(), Role(role))
       val ass = _associationState!!
       val updatedAssoc =
           Association(
               ass.uid,
-              ass.name,
-              ass.description,
-              ass.creationDate,
-              ass.status,
-              ass.members.filter { us -> us.uid != uid } + updatedUser,
-              ass.events)
+              ass.getName(),
+              ass.getDescription(),
+              ass.getCreationDate(),
+              ass.getStatus(),
+              ass.getMembers().filter { us -> us.uid != uid } + updatedUser,
+              ass.getEvents())
       associationDatabase.addAssociation(updatedAssoc)
     }
   }
@@ -96,12 +96,12 @@ class AssociationUtils(
       val updatedAssoc =
           Association(
               ass.uid,
-              ass.name,
-              ass.description,
-              ass.creationDate,
-              ass.status,
-              ass.members + User(user.uid, user.name, Role("pending")),
-              ass.events)
+              ass.getName(),
+              ass.getDescription(),
+              ass.getCreationDate(),
+              ass.getStatus(),
+              ass.getMembers() + User(user.uid, user.getName(), Role("pending")),
+              ass.getEvents())
       associationDatabase.addAssociation(updatedAssoc)
     }
   }
@@ -123,7 +123,7 @@ class AssociationUtils(
   }
 
   fun deleteAssoc() {
-    if (user.role != Role("president")) return
+    if (user.getRole() != Role("president")) return
     associationDatabase.deleteAssociation(assocId)
     assocId = ""
     _associationState = null
@@ -136,7 +136,7 @@ class AssociationUtils(
 
   fun getFilteredAssociations(searchQuery: String): List<Association> {
     return getAllAssociations().filter { ass ->
-      ass.name == searchQuery || ass.description == searchQuery
+      ass.getName() == searchQuery || ass.getDescription() == searchQuery
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
@@ -12,6 +12,9 @@ data class Association(
   constructor() : this("", "", "", "", "", listOf(), listOf())
 
   override fun equals(other: Any?): Boolean {
+    if (other?.javaClass != this.javaClass) {
+      return false
+    }
     if (this === other) return true
     other as Association
     return uid == other.uid

--- a/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
@@ -25,7 +25,6 @@ data class Association(
     return "Association(uid='$uid', name='$name', description='$description', creationDate='$creationDate', status='$status', members=$members, events=$events)"
   }
 
-
   fun getName(): String {
     return name
   }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Association.kt
@@ -1,13 +1,52 @@
 package com.github.se.assocify.model.entities
 
 data class Association(
-    var uid: String,
-    val name: String,
-    val description: String,
-    val creationDate: String,
-    val status: String,
-    val members: List<User>,
-    val events: List<Event>
+    val uid: String,
+    private val name: String,
+    private val description: String,
+    private val creationDate: String,
+    private val status: String,
+    private val members: List<User>,
+    private val events: List<Event>
 ) {
   constructor() : this("", "", "", "", "", listOf(), listOf())
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    other as Association
+    return uid == other.uid
+  }
+
+  override fun hashCode(): Int {
+    return uid.hashCode()
+  }
+
+  override fun toString(): String {
+    return "Association(uid='$uid', name='$name', description='$description', creationDate='$creationDate', status='$status', members=$members, events=$events)"
+  }
+
+
+  fun getName(): String {
+    return name
+  }
+
+  fun getDescription(): String {
+    return description
+  }
+
+  fun getCreationDate(): String {
+    return creationDate
+  }
+
+  fun getStatus(): String {
+    return status
+  }
+
+  fun getMembers(): List<User> {
+    return members
+  }
+
+  fun getEvents(): List<Event> {
+    return events
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
@@ -1,17 +1,20 @@
 package com.github.se.assocify.model.entities
 
 data class Event(
+    val uid: String = "",
+    private val name: String = "",
+    private val description: String = "",
     private val startDate: String,
     private val endDate: String,
     private val organizers: List<User>,
     private val staffers: List<User>
 ) {
-  constructor() : this("", "", listOf(), listOf())
+  constructor() : this("", "", "", "", "", listOf(), listOf())
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     other as Event
-    return startDate == other.startDate
+    return uid == other.uid
   }
 
   override fun hashCode(): Int {

--- a/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
@@ -1,10 +1,40 @@
 package com.github.se.assocify.model.entities
 
 data class Event(
-    val startDate: String,
-    val endDate: String,
-    val organizers: List<User>,
-    val staffers: List<User>
+    private val startDate: String,
+    private val endDate: String,
+    private val organizers: List<User>,
+    private val staffers: List<User>
 ) {
   constructor() : this("", "", listOf(), listOf())
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    other as Event
+    return startDate == other.startDate
+  }
+
+  override fun hashCode(): Int {
+    return startDate.hashCode()
+  }
+
+  override fun toString(): String {
+    return "Event(startDate='$startDate', endDate='$endDate', organizers=$organizers, staffers=$staffers)"
+  }
+
+  fun getStartDate(): String {
+    return startDate
+  }
+
+  fun getEndDate(): String {
+    return endDate
+  }
+
+  fun getOrganizers(): List<User> {
+    return organizers
+  }
+
+  fun getStaffers(): List<User> {
+    return staffers
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
@@ -12,6 +12,9 @@ data class Event(
   constructor() : this("", "", "", "", "", listOf(), listOf())
 
   override fun equals(other: Any?): Boolean {
+      if (other?.javaClass != this.javaClass) {
+          return false
+      }
     if (this === other) return true
     other as Event
     return uid == other.uid

--- a/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Event.kt
@@ -12,9 +12,9 @@ data class Event(
   constructor() : this("", "", "", "", "", listOf(), listOf())
 
   override fun equals(other: Any?): Boolean {
-      if (other?.javaClass != this.javaClass) {
-          return false
-      }
+    if (other?.javaClass != this.javaClass) {
+      return false
+    }
     if (this === other) return true
     other as Event
     return uid == other.uid

--- a/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
@@ -10,6 +10,9 @@ data class Role(private val name: String) {
    * @return true if the name of the role is the same as the name of the other role
    */
   override fun equals(other: Any?): Boolean {
+    if (other?.javaClass != this.javaClass) {
+      return false
+    }
     if (this === other) return true
     other as Role
     return name == other.name

--- a/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Role.kt
@@ -1,5 +1,44 @@
 package com.github.se.assocify.model.entities
 
-data class Role(val name: String) {
+data class Role(private val name: String) {
   constructor() : this("")
+
+  /**
+   * Returns true if the name of the role is the same as the name of the other role
+   *
+   * @param other the other role to compare
+   * @return true if the name of the role is the same as the name of the other role
+   */
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    other as Role
+    return name == other.name
+  }
+
+  /**
+   * Returns the hash code of the name of the role
+   *
+   * @return the hash code of the name of the role
+   */
+  override fun hashCode(): Int {
+    return name.hashCode()
+  }
+
+  /**
+   * Returns the string representation of the role
+   *
+   * @return the string representation of the role
+   */
+  override fun toString(): String {
+    return "Role(name='$name')"
+  }
+
+  /**
+   * Returns the name of the role
+   *
+   * @return the name of the role
+   */
+  fun getName(): String {
+    return name
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/model/entities/User.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/User.kt
@@ -4,6 +4,9 @@ data class User(val uid: String, private val name: String, private val role: Rol
   constructor() : this("", "", Role("pending"))
 
   override fun equals(other: Any?): Boolean {
+    if (other?.javaClass != this.javaClass) {
+      return false
+    }
     if (this === other) return true
     other as User
     return uid == other.uid

--- a/app/src/main/java/com/github/se/assocify/model/entities/User.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/User.kt
@@ -1,5 +1,27 @@
 package com.github.se.assocify.model.entities
 
-data class User(val uid: String, val name: String, val role: Role) {
+data class User(val uid: String, private val name: String, private val role: Role) {
   constructor() : this("", "", Role("pending"))
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    other as User
+    return uid == other.uid
+  }
+
+  override fun hashCode(): Int {
+    return uid.hashCode()
+  }
+
+  override fun toString(): String {
+    return "User(uid='$uid', name='$name', role=$role)"
+  }
+
+  fun getName(): String {
+    return name
+  }
+
+  fun getRole(): Role {
+    return role
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAsso/CreateAssoScreen.kt
@@ -96,8 +96,8 @@ fun CreateAssoScreen(viewmodel: CreateAssoViewmodel = CreateAssoViewmodel(listOf
                     ListItem(
                         modifier =
                             Modifier.clip(RoundedCornerShape(10.dp)).testTag("MemberListItem"),
-                        headlineContent = { Text(member.name) },
-                        overlineContent = { Text(member.role.name) },
+                        headlineContent = { Text(member.getName()) },
+                        overlineContent = { Text(member.getRole().getName()) },
                         leadingContent = {
                           Icon(Icons.Default.Person, contentDescription = "Person")
                         },

--- a/app/src/test/java/com/github/se/assocify/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/NavigationActionsTest.kt
@@ -6,7 +6,10 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
+@RunWith(JUnit4::class)
 class NavigationActionsTest {
 
   private val navController = mockk<NavHostController>()

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/AssociationTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/AssociationTest.kt
@@ -10,6 +10,20 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class AssociationTest {
+
+  @Test
+  fun testNotSameClassEquals() {
+    val event = Association()
+    assertEquals(false, event.equals("string"))
+  }
+
+  @Test
+  fun testSameObjectEquals() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assert(association.equals(association))
+  }
+
   @Test
   fun testEquals() {
     val association1 =

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/AssociationTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/AssociationTest.kt
@@ -5,7 +5,10 @@ import com.github.se.assocify.model.entities.Event
 import com.github.se.assocify.model.entities.User
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
+@RunWith(JUnit4::class)
 class AssociationTest {
   @Test
   fun testEquals() {

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/AssociationTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/AssociationTest.kt
@@ -1,0 +1,97 @@
+package com.github.se.assocify.navigation.model.entities
+
+import com.github.se.assocify.model.entities.Association
+import com.github.se.assocify.model.entities.Event
+import com.github.se.assocify.model.entities.User
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class AssociationTest {
+  @Test
+  fun testEquals() {
+    val association1 =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    val association2 =
+        Association("uid1", "name2", "description2", "creationDate2", "status2", listOf(), listOf())
+    assertEquals(association1, association2)
+  }
+
+  @Test
+  fun testNotEquals() {
+    val association1 =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    val association2 =
+        Association("uid2", "name2", "description2", "creationDate2", "status2", listOf(), listOf())
+    assertEquals(false, association1 == association2)
+  }
+
+  @Test
+  fun testHashCode() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals("uid1".hashCode(), association.hashCode())
+  }
+
+  @Test
+  fun testToString() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals(
+        "Association(uid='uid1', name='name1', description='description1', creationDate='creationDate1', status='status1', members=[], events=[])",
+        association.toString())
+  }
+
+  @Test
+  fun testGetName() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals("name1", association.getName())
+  }
+
+  @Test
+  fun testGetDescription() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals("description1", association.getDescription())
+  }
+
+  @Test
+  fun testGetCreationDate() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals("creationDate1", association.getCreationDate())
+  }
+
+  @Test
+  fun testGetStatus() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals("status1", association.getStatus())
+  }
+
+  @Test
+  fun testGetMembers() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals(listOf<User>(), association.getMembers())
+  }
+
+  @Test
+  fun testGetEvents() {
+    val association =
+        Association("uid1", "name1", "description1", "creationDate1", "status1", listOf(), listOf())
+    assertEquals(listOf<Event>(), association.getEvents())
+  }
+
+  @Test
+  fun testConstructor() {
+    val association = Association()
+    assertEquals("", association.uid)
+    assertEquals("", association.getName())
+    assertEquals("", association.getDescription())
+    assertEquals("", association.getCreationDate())
+    assertEquals("", association.getStatus())
+    assertEquals(listOf<User>(), association.getMembers())
+    assertEquals(listOf<Event>(), association.getEvents())
+  }
+}

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/EventTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/EventTest.kt
@@ -3,20 +3,23 @@ package com.github.se.assocify.navigation.model.entities
 import com.github.se.assocify.model.entities.Event
 import com.github.se.assocify.model.entities.User
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
+@RunWith(JUnit4::class)
 class EventTest {
   @Test
   fun testEquals() {
     val event1 = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
     val event2 = Event("uid1", "name2", " ", " ", "", listOf(), listOf())
-    assert(event1.equals(event2))
+    assert(event1 == event2)
   }
 
   @Test
   fun notEquals() {
     val event1 = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
     val event2 = Event("uid2", "name2", " ", " ", "", listOf(), listOf())
-    assert(!event1.equals(event2))
+    assert(event1 != event2)
   }
 
   @Test
@@ -47,12 +50,12 @@ class EventTest {
   @Test
   fun testGetOrganizers() {
     val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
-    assert(event.getOrganizers().equals(listOf<User>()))
+    assert(event.getOrganizers() == listOf<User>())
   }
 
   @Test
   fun testGetStaffers() {
     val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
-    assert(event.getStaffers().equals(listOf<User>()))
+    assert(event.getStaffers() == listOf<User>())
   }
 }

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/EventTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/EventTest.kt
@@ -1,0 +1,58 @@
+package com.github.se.assocify.navigation.model.entities
+
+import com.github.se.assocify.model.entities.Event
+import com.github.se.assocify.model.entities.User
+import org.junit.Test
+
+class EventTest {
+  @Test
+  fun testEquals() {
+    val event1 = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    val event2 = Event("uid1", "name2", " ", " ", "", listOf(), listOf())
+    assert(event1.equals(event2))
+  }
+
+  @Test
+  fun notEquals() {
+    val event1 = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    val event2 = Event("uid2", "name2", " ", " ", "", listOf(), listOf())
+    assert(!event1.equals(event2))
+  }
+
+  @Test
+  fun testHashCode() {
+    val event1 = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    val event2 = Event("uid1", "name2", " ", " ", "", listOf(), listOf())
+    assert(event1.hashCode() == event2.hashCode())
+  }
+
+  @Test
+  fun testToString() {
+    val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    assert(event.toString() == "Event(startDate=' ', endDate='', organizers=[], staffers=[])")
+  }
+
+  @Test
+  fun testGetStartDate() {
+    val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    assert(event.getStartDate() == " ")
+  }
+
+  @Test
+  fun testGetEndDate() {
+    val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    assert(event.getEndDate() == "")
+  }
+
+  @Test
+  fun testGetOrganizers() {
+    val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    assert(event.getOrganizers().equals(listOf<User>()))
+  }
+
+  @Test
+  fun testGetStaffers() {
+    val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    assert(event.getStaffers().equals(listOf<User>()))
+  }
+}

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/EventTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/EventTest.kt
@@ -2,6 +2,7 @@ package com.github.se.assocify.navigation.model.entities
 
 import com.github.se.assocify.model.entities.Event
 import com.github.se.assocify.model.entities.User
+import junit.framework.TestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -13,6 +14,18 @@ class EventTest {
     val event1 = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
     val event2 = Event("uid1", "name2", " ", " ", "", listOf(), listOf())
     assert(event1 == event2)
+  }
+
+  @Test
+  fun testNotSameClassEquals() {
+    val event = Event()
+    TestCase.assertEquals(false, event.equals("string"))
+  }
+
+  @Test
+  fun testSameObjectEquals() {
+    val event = Event("uid1", "name1", " ", " ", "", listOf(), listOf())
+    assert(event.equals(event))
   }
 
   @Test

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/RoleTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/RoleTest.kt
@@ -1,0 +1,40 @@
+package com.github.se.assocify.navigation.model.entities
+
+import com.github.se.assocify.model.entities.Role
+import org.junit.Test
+
+class RoleTest {
+
+  @Test
+  fun testEquals() {
+    val role1 = Role("admin")
+    val role2 = Role("admin")
+    assert(role1.equals(role2))
+  }
+
+  @Test
+  fun notEquals() {
+    val role1 = Role("admin")
+    val role2 = Role("staff")
+    assert(!role1.equals(role2))
+  }
+
+  @Test
+  fun testHashCode() {
+    val role1 = Role("admin")
+    val role2 = Role("admin")
+    assert(role1.hashCode() == role2.hashCode())
+  }
+
+  @Test
+  fun testToString() {
+    val role = Role("admin")
+    assert(role.toString() == "Role(name='admin')")
+  }
+
+  @Test
+  fun testGetName() {
+    val role = Role("admin")
+    assert(role.getName() == "admin")
+  }
+}

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/RoleTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/RoleTest.kt
@@ -1,6 +1,7 @@
 package com.github.se.assocify.navigation.model.entities
 
 import com.github.se.assocify.model.entities.Role
+import junit.framework.TestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -13,6 +14,18 @@ class RoleTest {
     val role1 = Role("admin")
     val role2 = Role("admin")
     assert(role1 == role2)
+  }
+
+  @Test
+  fun testNotSameClassEquals() {
+    val role = Role()
+    TestCase.assertEquals(false, role.equals("string"))
+  }
+
+  @Test
+  fun testSameObjectEquals() {
+    val role = Role("admin")
+    assert(role.equals(role))
   }
 
   @Test

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/RoleTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/RoleTest.kt
@@ -2,21 +2,24 @@ package com.github.se.assocify.navigation.model.entities
 
 import com.github.se.assocify.model.entities.Role
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
+@RunWith(JUnit4::class)
 class RoleTest {
 
   @Test
   fun testEquals() {
     val role1 = Role("admin")
     val role2 = Role("admin")
-    assert(role1.equals(role2))
+    assert(role1 == role2)
   }
 
   @Test
   fun notEquals() {
     val role1 = Role("admin")
     val role2 = Role("staff")
-    assert(!role1.equals(role2))
+    assert(role1 != role2)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/UserTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/UserTest.kt
@@ -3,7 +3,10 @@ package com.github.se.assocify.navigation.model.entities
 import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
+@RunWith(JUnit4::class)
 class UserTest {
 
   @Test

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/UserTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/UserTest.kt
@@ -2,6 +2,7 @@ package com.github.se.assocify.navigation.model.entities
 
 import com.github.se.assocify.model.entities.Role
 import com.github.se.assocify.model.entities.User
+import junit.framework.TestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -14,6 +15,18 @@ class UserTest {
     val user1 = User("1", "John Doe", Role("admin"))
     val user2 = User("1", "Jane Doe", Role("admin"))
     assert(user1 == user2)
+  }
+
+  @Test
+  fun testSameObjectEquals() {
+    val user = User("1", "John Doe", Role("admin"))
+    assert(user.equals(user))
+  }
+
+  @Test
+  fun testNotSameClassEquals() {
+    val user = User()
+    TestCase.assertEquals(false, user.equals("string"))
   }
 
   @Test

--- a/app/src/test/java/com/github/se/assocify/navigation/model/entities/UserTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/model/entities/UserTest.kt
@@ -1,0 +1,47 @@
+package com.github.se.assocify.navigation.model.entities
+
+import com.github.se.assocify.model.entities.Role
+import com.github.se.assocify.model.entities.User
+import org.junit.Test
+
+class UserTest {
+
+  @Test
+  fun testEquals() {
+    val user1 = User("1", "John Doe", Role("admin"))
+    val user2 = User("1", "Jane Doe", Role("admin"))
+    assert(user1 == user2)
+  }
+
+  @Test
+  fun notEquals() {
+    val user1 = User("1", "John Doe", Role("admin"))
+    val user2 = User("2", "Jane Doe", Role("admin"))
+    assert(user1 != user2)
+  }
+
+  @Test
+  fun testHashCode() {
+    val user1 = User("1", "John Doe", Role("admin"))
+    val user2 = User("1", "Jane Doe", Role("admin"))
+    assert(user1.hashCode() == user2.hashCode())
+  }
+
+  @Test
+  fun testToString() {
+    val user = User("1", "John Doe", Role("admin"))
+    assert(user.toString() == "User(uid='1', name='John Doe', role=Role(name='admin'))")
+  }
+
+  @Test
+  fun testGetName() {
+    val user = User("1", "John Doe", Role("admin"))
+    assert(user.getName() == "John Doe")
+  }
+
+  @Test
+  fun testGetRole() {
+    val user = User("1", "John Doe", Role("admin"))
+    assert(user.getRole() == Role("admin"))
+  }
+}


### PR DESCRIPTION
I added some basic methods to all entities including :
- [x] Getter
- [x] Equals
- [x] toString
- [x] hashCode
- [x] Private Attributes
- [x] Entity tests
- [x] Add Junit annotations to tests classes to allow test them all at once with tasks.

I also put the main attributes of entities in private to force going by the getters for better maintanability and reduce developer mistakes.