### PR TITLE
Fixing exceptions which should not be thrown in APIs

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/AssociationAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AssociationAPI.kt
@@ -16,7 +16,8 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
    * Gets an association from the database
    *
    * @param id the id of the association to get
-   * @param callback the callback to call with the association
+   * @param callback the callback to call with the association, it isn't called if the association
+   *   isn't found
    * @return the association with the given id
    */
   fun getAssociation(id: String, callback: (Association) -> Unit): Task<Unit> {
@@ -27,8 +28,6 @@ class AssociationAPI(db: FirebaseFirestore) : FirebaseApi(db) {
         if (document != null && document.exists()) {
           val doc = document.toObject(Association::class.java)
           callback(doc!!)
-        } else {
-          throw Exception("No Asso found with ID: $id")
         }
       } else {
         throw task.exception ?: Exception("Unknown error occurred")

--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -37,7 +37,7 @@ class UserAPI(db: FirebaseFirestore) : FirebaseApi(db) {
   /**
    * Gets all users from the database
    *
-   * @param callback the callback to call with the list of users
+   * @param callback the callback to call with the list of users it isn't called if the user isn't found
    * @return a list of all users
    */
   fun getAllUsers(callback: (List<User>) -> Unit): Task<Unit> {

--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -28,8 +28,6 @@ class UserAPI(db: FirebaseFirestore) : FirebaseApi(db) {
         if (document != null && document.exists()) {
           val user = document.toObject(User::class.java)
           callback(user!!)
-        } else {
-          throw Exception("No User found with ID: $id")
         }
       } else {
         throw task.exception ?: Exception("Unknown error occurred")


### PR DESCRIPTION
In getUser(uid) and get Association(uid) an exception was thrown when user/association wasn't found.

I corrected this problem.