### PR TITLE
ci: add building APK

### DIFF
--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
           echo $ENCODED_KEYSTORE | base64 -di > keystore.jks
-          echo $ENCODED_PASSWORDS | base64 -di passwords-b64.txt > keystore.properties
+          echo $ENCODED_PASSWORDS | base64 -di > keystore.properties
 
       - name: Build Release apk
         run: |

--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -5,6 +5,11 @@ on:
       name:
         description: "Release-Build"
         default: "Generate release build"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -5,11 +5,6 @@ on:
       name:
         description: "Release-Build"
         default: "Generate release build"
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -1,0 +1,55 @@
+name: APK Generation
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Release-Build"
+        default: "Generate release build"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out branch
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x ./gradlew
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2.0.10
+
+      - name: Decode Signing Data
+        env:
+          ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE }}
+          ENCODED_PASSWORDS: ${{ secrets.KEYSTORE_PASSWORDS }}
+
+        run: |
+          echo $ENCODED_KEYSTORE > keystore-b64.txt
+          base64 -d keystore-b64.txt > keystore.jks
+          echo $ENCODED_PASSWORDS > passwords-b64.txt
+          base64 -d passwords-b64.txt > keystore.properties
+
+      - name: Build Release apk
+        run: |
+          ./gradlew assembleRelease
+
+      - name: Get release file apk path
+        id: releaseApk
+        run: echo "apkfile=$(find app/build/outputs/apk/release/*.apk)" >> $GITHUB_OUTPUT
+
+      - name: Upload Release Build to Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: ${{ steps.releaseApk.outputs.apkfile }}

--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -36,14 +36,14 @@ jobs:
 
       - name: Decode Signing Data
         env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE }}
           ENCODED_PASSWORDS: ${{ secrets.KEYSTORE_PASSWORDS }}
 
         run: |
-          echo $ENCODED_KEYSTORE > keystore-b64.txt
-          base64 -d keystore-b64.txt > keystore.jks
-          echo $ENCODED_PASSWORDS > passwords-b64.txt
-          base64 -d passwords-b64.txt > keystore.properties
+          echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
+          echo $ENCODED_KEYSTORE | base64 -di > keystore.jks
+          echo $ENCODED_PASSWORDS | base64 -di passwords-b64.txt > keystore.properties
 
       - name: Build Release apk
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,12 @@ jobs:
       - name: Create google-services.json file
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE }}
           ENCODED_PASSWORDS: ${{ secrets.KEYSTORE_PASSWORDS }}
         run: |
           echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
-          echo $ENCODED_PASSWORDS | base64 -di > ./keystore.properties 
+          echo $ENCODED_KEYSTORE | base64 -di > keystore.jks
+          echo $ENCODED_PASSWORDS | base64 -di > keystore.properties
 
       - name: Grant execute permission for gradlew
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
       - name: Create google-services.json file
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          ENCODED_PASSWORDS: ${{ secrets.KEYSTORE_PASSWORDS }}
         run: |
           echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
+          echo $ENCODED_PASSWORDS | base64 -di > ./keystore.properties 
 
       - name: Grant execute permission for gradlew
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .DS_Store
 captures
 local.properties
+keystore.properties
 
 # Gradle files
 .gradle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
     id("com.android.application")
@@ -25,8 +27,29 @@ android {
         }
     }
 
+    val keystorePropertiesFile = rootProject.file("keystore.properties")
+
+    // Initialize a new Properties() object called keystoreProperties.
+    val keystoreProperties = Properties()
+
+    // Load your keystore.properties file into the keystoreProperties object.
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+
+    signingConfigs {
+        create("release") {
+            // You need to specify either an absolute path or include the
+            // keystore file in the same directory as the build.gradle file.
+            storeFile = file("../keystore.jks")
+            storePassword = keystoreProperties["storePassword"] as String
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+        }
+    }
+
+
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
"You must set up your repo with a GitHub workflow to build the app's APK such that, at the end of every Sprint, you can create a new release at the push of a button." - M1

This sets that up.