### PR TITLE
Receipt Navigation

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
-import com.github.se.assocify.model.database.ReceiptsAPI
+import com.github.se.assocify.model.database.ReceiptAPI
 import com.github.se.assocify.model.entities.Phase
 import com.github.se.assocify.model.entities.Receipt
 import com.github.se.assocify.navigation.NavigationActions
@@ -34,7 +34,7 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   @get:Rule val composeTestRule = createComposeRule()
 
   private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
-  private val receiptsAPI = mockk<ReceiptsAPI>(relaxUnitFun = true)
+  private val receiptsAPI = mockk<ReceiptAPI>(relaxUnitFun = true)
   private val viewModel = ReceiptViewModel(navActions = navActions, receiptApi = receiptsAPI)
   private val viewModel2 =
       ReceiptViewModel(
@@ -221,7 +221,7 @@ class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   @get:Rule val composeTestRule = createComposeRule()
 
   private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
-  private val receiptsAPI = mockk<ReceiptsAPI>(relaxUnitFun = true)
+  private val receiptsAPI = mockk<ReceiptAPI>(relaxUnitFun = true)
   private val viewModel =
       ReceiptViewModel(
           receiptUid = "testReceipt", navActions = navActions, receiptApi = receiptsAPI)

--- a/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
@@ -33,49 +33,36 @@ import org.junit.runner.RunWith
 class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
 
-  private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
-  private val receiptsAPI = mockk<ReceiptAPI>(relaxUnitFun = true)
-  private val viewModel = ReceiptViewModel(navActions = navActions, receiptApi = receiptsAPI)
-  private val viewModel2 =
-      ReceiptViewModel(
-          receiptUid = "testReceipt", navActions = navActions, receiptApi = receiptsAPI)
-
-  private var expectedReceipt =
-      Receipt(
-          uid = "testReceipt",
-          title = "Test Title",
-          description = "",
-          cents = 10000,
-          date = DateUtil.toDate("01/01/2021")!!,
-          incoming = false,
-          phase = Phase.Unapproved,
-          photo = null,
-      )
-
   private var capturedReceipt: Receipt? = null
+  private var expectedReceipt =
+        Receipt(
+            uid = "testReceipt",
+            title = "Test Title",
+            description = "",
+            cents = 10000,
+            date = DateUtil.toDate("01/01/2021")!!,
+            incoming = false,
+            phase = Phase.Unapproved,
+            photo = null,
+        )
 
-  private var receiptList =
-      listOf(
-          Receipt(
-              uid = "testReceipt",
-              title = "Edited Receipt",
-              description = "",
-              cents = 10000,
-              date = DateUtil.toDate("01/01/2021")!!,
-              incoming = false,
-              phase = Phase.Unapproved,
-              photo = null,
-          ))
+  private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
+  private val receiptAPI = mockk<ReceiptAPI>(){
+      every { uploadReceipt(any(), any(), any(), any()) } answers
+              {
+                  capturedReceipt = firstArg<Receipt>()
+                  println("capturedReceiptRightNow: $capturedReceipt")
+                  navActions.back()
+              }
+      every { getNewId() } returns "testReceipt"
+      every { deleteReceipt(any(), any(), any()) } answers { }
+  }
+  private val viewModel = ReceiptViewModel(navActions = navActions, receiptApi = receiptAPI)
 
   @Before
   fun testSetup() {
     CurrentUser.userUid = "testUser"
     CurrentUser.associationUid = "testUser"
-    every { receiptsAPI.uploadReceipt(any(), any(), any(), any()) } answers
-        {
-          capturedReceipt = firstArg()
-          navActions.back()
-        }
     composeTestRule.setContent { ReceiptScreen(navActions = navActions, viewModel = viewModel) }
   }
 
@@ -155,10 +142,10 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   fun incoming() {
     with(composeTestRule) {
       onNodeWithTag("earningChip").performScrollTo().performClick()
-      assert(viewModel.uiState.value.incoming == true)
+      assert(viewModel.uiState.value.incoming)
 
       onNodeWithTag("expenseChip").performScrollTo().performClick()
-      assert(viewModel.uiState.value.incoming == false)
+      assert(!viewModel.uiState.value.incoming)
     }
   }
 
@@ -184,7 +171,9 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
       assert(viewModel.uiState.value.amountError == null)
       assert(viewModel.uiState.value.dateError == null)
 
-      onNodeWithTag("saveButton").performClick()
+      onNodeWithTag("saveButton").performScrollTo().performClick()
+      verify { receiptAPI.uploadReceipt(any(), any(), any(), any()) }
+      assert(capturedReceipt == expectedReceipt)
     }
   }
 
@@ -220,54 +209,54 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
 class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
 
+    private var receiptList =
+        listOf(
+        Receipt(
+            uid = "testReceipt",
+            title = "Edited Receipt",
+            description = "",
+            cents = 10000,
+            date = DateUtil.toDate("01/01/2021")!!,
+            incoming = false,
+            phase = Phase.Unapproved,
+            photo = null,
+        ))
+
+    private var expectedReceipt =
+        Receipt(
+            uid = "testReceipt",
+            title = "Test Title",
+            description = "",
+            cents = 10000,
+            date = DateUtil.toDate("01/01/2021")!!,
+            incoming = false,
+            phase = Phase.Unapproved,
+            photo = null,
+        )
+    private var capturedReceipt: Receipt? = null
+
   private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
-  private val receiptsAPI = mockk<ReceiptAPI>(relaxUnitFun = true)
+  private val receiptsAPI = mockk<ReceiptAPI> {
+      every { uploadReceipt(any(), any(), any(), any()) } answers
+              {
+                  capturedReceipt = firstArg()
+                  navActions.back()
+              }
+      every { getUserReceipts(any(), any()) } answers
+              {
+                  firstArg<(List<Receipt>) -> Unit>().invoke(receiptList)
+                  navActions.back()
+              }
+      every { getNewId() } answers { "testReceipt" }
+  }
   private val viewModel =
       ReceiptViewModel(
           receiptUid = "testReceipt", navActions = navActions, receiptApi = receiptsAPI)
-
-  private var expectedReceipt =
-      Receipt(
-          uid = "testReceipt",
-          title = "Test Title",
-          description = "",
-          cents = 10000,
-          date = DateUtil.toDate("01/01/2021")!!,
-          incoming = false,
-          phase = Phase.Unapproved,
-          photo = null,
-      )
-
-  private var capturedReceipt: Receipt? = null
-
-  private var receiptList =
-      listOf(
-          Receipt(
-              uid = "testReceipt",
-              title = "Edited Receipt",
-              description = "",
-              cents = 10000,
-              date = DateUtil.toDate("01/01/2021")!!,
-              incoming = false,
-              phase = Phase.Unapproved,
-              photo = null,
-          ))
 
   @Before
   fun testSetup() {
     CurrentUser.userUid = "testUser"
     CurrentUser.associationUid = "testUser"
-    every { receiptsAPI.uploadReceipt(any(), any(), any(), any()) } answers
-        {
-          capturedReceipt = firstArg()
-          navActions.back()
-        }
-    every { receiptsAPI.getUserReceipts(any(), any()) } answers
-        {
-          firstArg<(List<Receipt>) -> Unit>().invoke(receiptList)
-          navActions.back()
-          println("TEST:getUserReceipts")
-        }
     composeTestRule.setContent { ReceiptScreen(navActions = navActions, viewModel = viewModel) }
   }
 
@@ -277,6 +266,9 @@ class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
       onNodeWithTag("receiptScreen").assertIsDisplayed()
       onNodeWithTag("receiptScreenTitle").assertIsDisplayed().assertTextContains("Edit Receipt")
       verify { receiptsAPI.getUserReceipts(any(), any()) }
+      onNodeWithTag("titleField").assertTextContains("Edited Receipt")
+      onNodeWithTag("amountField").assertTextContains("100.00")
+      onNodeWithTag("dateField").assertTextContains("01/01/2021")
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
@@ -35,28 +35,29 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
 
   private var capturedReceipt: Receipt? = null
   private var expectedReceipt =
-        Receipt(
-            uid = "testReceipt",
-            title = "Test Title",
-            description = "",
-            cents = 10000,
-            date = DateUtil.toDate("01/01/2021")!!,
-            incoming = false,
-            phase = Phase.Unapproved,
-            photo = null,
-        )
+      Receipt(
+          uid = "testReceipt",
+          title = "Test Title",
+          description = "",
+          cents = 10000,
+          date = DateUtil.toDate("01/01/2021")!!,
+          incoming = false,
+          phase = Phase.Unapproved,
+          photo = null,
+      )
 
   private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
-  private val receiptAPI = mockk<ReceiptAPI>(){
-      every { uploadReceipt(any(), any(), any(), any()) } answers
-              {
-                  capturedReceipt = firstArg<Receipt>()
-                  println("capturedReceiptRightNow: $capturedReceipt")
-                  navActions.back()
-              }
-      every { getNewId() } returns "testReceipt"
-      every { deleteReceipt(any(), any(), any()) } answers { }
-  }
+  private val receiptAPI =
+      mockk<ReceiptAPI>() {
+        every { uploadReceipt(any(), any(), any(), any()) } answers
+            {
+              capturedReceipt = firstArg<Receipt>()
+              println("capturedReceiptRightNow: $capturedReceipt")
+              navActions.back()
+            }
+        every { getNewId() } returns "testReceipt"
+        every { deleteReceipt(any(), any(), any()) } answers {}
+      }
   private val viewModel = ReceiptViewModel(navActions = navActions, receiptApi = receiptAPI)
 
   @Before
@@ -209,46 +210,47 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
 class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
 
-    private var receiptList =
-        listOf(
-        Receipt(
-            uid = "testReceipt",
-            title = "Edited Receipt",
-            description = "",
-            cents = 10000,
-            date = DateUtil.toDate("01/01/2021")!!,
-            incoming = false,
-            phase = Phase.Unapproved,
-            photo = null,
-        ))
+  private var receiptList =
+      listOf(
+          Receipt(
+              uid = "testReceipt",
+              title = "Edited Receipt",
+              description = "",
+              cents = 10000,
+              date = DateUtil.toDate("01/01/2021")!!,
+              incoming = false,
+              phase = Phase.Unapproved,
+              photo = null,
+          ))
 
-    private var expectedReceipt =
-        Receipt(
-            uid = "testReceipt",
-            title = "Test Title",
-            description = "",
-            cents = 10000,
-            date = DateUtil.toDate("01/01/2021")!!,
-            incoming = false,
-            phase = Phase.Unapproved,
-            photo = null,
-        )
-    private var capturedReceipt: Receipt? = null
+  private var expectedReceipt =
+      Receipt(
+          uid = "testReceipt",
+          title = "Test Title",
+          description = "",
+          cents = 10000,
+          date = DateUtil.toDate("01/01/2021")!!,
+          incoming = false,
+          phase = Phase.Unapproved,
+          photo = null,
+      )
+  private var capturedReceipt: Receipt? = null
 
   private val navActions = mockk<NavigationActions>(relaxUnitFun = true)
-  private val receiptsAPI = mockk<ReceiptAPI> {
-      every { uploadReceipt(any(), any(), any(), any()) } answers
-              {
-                  capturedReceipt = firstArg()
-                  navActions.back()
-              }
-      every { getUserReceipts(any(), any()) } answers
-              {
-                  firstArg<(List<Receipt>) -> Unit>().invoke(receiptList)
-                  navActions.back()
-              }
-      every { getNewId() } answers { "testReceipt" }
-  }
+  private val receiptsAPI =
+      mockk<ReceiptAPI> {
+        every { uploadReceipt(any(), any(), any(), any()) } answers
+            {
+              capturedReceipt = firstArg()
+              navActions.back()
+            }
+        every { getUserReceipts(any(), any()) } answers
+            {
+              firstArg<(List<Receipt>) -> Unit>().invoke(receiptList)
+              navActions.back()
+            }
+        every { getNewId() } answers { "testReceipt" }
+      }
   private val viewModel =
       ReceiptViewModel(
           receiptUid = "testReceipt", navActions = navActions, receiptApi = receiptsAPI)

--- a/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
@@ -11,7 +11,7 @@ import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.storage.FirebaseStorage
 import java.time.LocalDate
 
-class ReceiptsAPI(
+class ReceiptAPI(
     userId: String,
     basePath: String,
     storage: FirebaseStorage,
@@ -31,7 +31,7 @@ class ReceiptsAPI(
    * @param onReceiptUploadSuccess called when the receipt data has been uploaded successfully.
    * @param onFailure called when any upload has failed. The boolean parameter indicates whether it
    *   failed on the receipt or the image (`true` when the receipt failed). The second parameter is
-   *   the exception that occured.
+   *   the exception that occurred.
    */
   fun uploadReceipt(
       receipt: Receipt,

--- a/app/src/main/java/com/github/se/assocify/navigation/Destination.kt
+++ b/app/src/main/java/com/github/se/assocify/navigation/Destination.kt
@@ -27,7 +27,9 @@ sealed class Destination(
 
   data object CreateAsso : Destination("login/createAsso")
 
-  data object Receipt : Destination("treasury/receipt")
+  data object NewReceipt : Destination("treasury/receipt")
+
+  data class EditReceipt(val receiptUid: String) : Destination("treasury/receipt/$receiptUid")
 }
 
 val MAIN_TABS_LIST =

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/ReceiptListViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/ReceiptListViewModel.kt
@@ -1,10 +1,12 @@
 package com.github.se.assocify.ui.screens.treasury
 
 import com.github.se.assocify.model.CurrentUser
-import com.github.se.assocify.model.database.ReceiptsAPI
+import com.github.se.assocify.model.database.ReceiptAPI
 import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.model.entities.Receipt
 import com.github.se.assocify.model.entities.User
+import com.github.se.assocify.navigation.Destination
+import com.github.se.assocify.navigation.NavigationActions
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.storage
@@ -18,8 +20,9 @@ import kotlinx.coroutines.flow.StateFlow
  * @param receiptsDatabase: Database API for receipts. A default one is passed
  */
 class ReceiptListViewModel(
-    private val receiptsDatabase: ReceiptsAPI =
-        ReceiptsAPI(
+    private val navActions: NavigationActions,
+    private val receiptsDatabase: ReceiptAPI =
+        ReceiptAPI(
             userId = CurrentUser.userUid!!,
             basePath = "associations/" + CurrentUser.associationUid!!,
             storage = Firebase.storage,
@@ -94,6 +97,10 @@ class ReceiptListViewModel(
             userReceipts = _uiState.value.userReceipts,
             allReceipts = _uiState.value.allReceipts,
             searchQuery = query)
+  }
+
+  fun onReceiptClick(receipt: Receipt) {
+    navActions.navigateTo(Destination.EditReceipt(receipt.uid))
   }
 }
 

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
+import com.github.se.assocify.ui.screens.treasury.receipt.receiptGraph
 
 fun NavGraphBuilder.treasuryGraph(navigationActions: NavigationActions) {
   composable(
@@ -11,4 +12,5 @@ fun NavGraphBuilder.treasuryGraph(navigationActions: NavigationActions) {
   ) {
     TreasuryScreen(navigationActions)
   }
+  receiptGraph(navigationActions)
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
@@ -1,8 +1,8 @@
 package com.github.se.assocify.ui.screens.treasury
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,7 +47,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -57,6 +56,8 @@ import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.MAIN_TABS_LIST
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.composables.MainNavigationBar
+import com.github.se.assocify.ui.util.DateUtil
+import com.github.se.assocify.ui.util.PriceUtil
 import kotlinx.coroutines.launch
 
 // Index of each tag for navigation
@@ -71,12 +72,11 @@ enum class PageIndex(val index: Int) {
 }
 
 /** Treasury Screen composable */
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TreasuryScreen(
     navActions: NavigationActions,
-    viewModel: ReceiptListViewModel = ReceiptListViewModel()
+    viewModel: ReceiptListViewModel = ReceiptListViewModel(navActions)
 ) {
   val viewmodelState by viewModel.uiState.collectAsState()
 
@@ -94,7 +94,7 @@ fun TreasuryScreen(
             modifier = Modifier.testTag("createReceipt"),
             containerColor = MaterialTheme.colorScheme.surface,
             contentColor = MaterialTheme.colorScheme.primary,
-            onClick = { navActions.navigateTo(Destination.Receipt) },
+            onClick = { navActions.navigateTo(Destination.NewReceipt) },
         ) {
           Icon(Icons.Outlined.Add, "Create")
         }
@@ -179,7 +179,7 @@ private fun MyReceiptPage(viewModel: ReceiptListViewModel) {
         // Header for the user receipts
         item {
           Text(
-              text = "My created receipts",
+              text = "My Receipts",
               style = MaterialTheme.typography.titleMedium,
               modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp))
           HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
@@ -189,7 +189,7 @@ private fun MyReceiptPage(viewModel: ReceiptListViewModel) {
           // First list of receipts
           viewmodelState.userReceipts.forEach { receipt ->
             item {
-              ReceiptItem(receipt)
+              ReceiptItem(receipt, viewModel)
               HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
             }
           }
@@ -209,7 +209,7 @@ private fun MyReceiptPage(viewModel: ReceiptListViewModel) {
           // Header for the global receipts
           item {
             Text(
-                text = "All receipts",
+                text = "All Receipts",
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp))
             HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
@@ -217,7 +217,7 @@ private fun MyReceiptPage(viewModel: ReceiptListViewModel) {
           // Second list of receipts
           viewmodelState.allReceipts.forEach { receipt ->
             item {
-              ReceiptItem(receipt)
+              ReceiptItem(receipt, viewModel)
               HorizontalDivider(modifier = Modifier.padding(start = 20.dp, end = 20.dp))
             }
           }
@@ -341,65 +341,68 @@ fun TreasuryTopBar(
 
 /** Receipt item from the list in My Receipts page */
 @Composable
-private fun ReceiptItem(receipt: Receipt) {
-  Box(modifier = Modifier.fillMaxWidth().padding(6.dp).height(70.dp).testTag("receiptItemBox")) {
-    Column(modifier = Modifier.padding(start = 20.dp)) {
-      Text(
-          text = receipt.date.toString(),
-          modifier = Modifier.padding(top = 6.dp).testTag("receiptDateText"),
-          style =
-              TextStyle(
-                  fontSize = 12.sp,
-                  lineHeight = 16.sp,
-                  color = Color(0xFF505050),
-                  letterSpacing = 0.5.sp,
-              ))
-      Text(
-          text = receipt.title,
-          modifier = Modifier.testTag("receiptNameText"),
-          style =
-              TextStyle(
-                  fontSize = 16.sp,
-                  lineHeight = 24.sp,
-                  color = Color(0xFF000000),
-                  letterSpacing = 0.sp,
-              ))
-      Text(
-          text = receipt.description,
-          modifier = Modifier.testTag("receiptDescriptionText"),
-          style =
-              TextStyle(
-                  fontSize = 14.sp,
-                  lineHeight = 24.sp,
-                  color = Color(0xFF505050),
-                  letterSpacing = 0.sp,
-              ))
-    }
-
-    Row(
-        modifier =
-            Modifier.align(Alignment.TopEnd)
-                .padding(end = 16.dp, top = 8.dp)
-                .testTag("receiptPriceAndIconRow"),
-        verticalAlignment = Alignment.CenterVertically) {
+private fun ReceiptItem(receipt: Receipt, viewModel: ReceiptListViewModel) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth().padding(6.dp).height(70.dp).testTag("receiptItemBox").clickable {
+            viewModel.onReceiptClick(receipt)
+          }) {
+        Column(modifier = Modifier.padding(start = 20.dp)) {
           Text(
-              text = (receipt.cents / 100.0).toString() + ".-",
-              modifier = Modifier.testTag("receiptPriceText"),
+              text = DateUtil.toString(receipt.date),
+              modifier = Modifier.padding(top = 6.dp).testTag("receiptDateText"),
               style =
                   TextStyle(
-                      fontSize = 14.sp,
+                      fontSize = 12.sp,
+                      lineHeight = 16.sp,
+                      color = MaterialTheme.colorScheme.secondary,
+                      letterSpacing = 0.5.sp,
+                  ))
+          Text(
+              text = receipt.title,
+              modifier = Modifier.testTag("receiptNameText"),
+              style =
+                  TextStyle(
+                      fontSize = 16.sp,
                       lineHeight = 24.sp,
-                      color = Color(0xFF505050),
                       letterSpacing = 0.sp,
                   ))
-          Spacer(modifier = Modifier.width(8.dp))
-          Icon(
-              modifier = Modifier.size(20.dp).testTag("shoppingCartIcon"),
-              imageVector = Icons.Filled.ShoppingCart,
-              contentDescription = "Arrow icon",
-          )
+          Text(
+              text = receipt.description,
+              modifier = Modifier.testTag("receiptDescriptionText"),
+              style =
+                  TextStyle(
+                      fontSize = 12.sp,
+                      lineHeight = 24.sp,
+                      color = MaterialTheme.colorScheme.secondary,
+                      letterSpacing = 0.sp,
+                  ))
         }
-  }
+
+        Row(
+            modifier =
+                Modifier.align(Alignment.TopEnd)
+                    .padding(end = 16.dp, top = 8.dp)
+                    .testTag("receiptPriceAndIconRow"),
+            verticalAlignment = Alignment.CenterVertically) {
+              Text(
+                  text = PriceUtil.fromCents(receipt.cents),
+                  modifier = Modifier.testTag("receiptPriceText"),
+                  style =
+                      TextStyle(
+                          fontSize = 14.sp,
+                          lineHeight = 24.sp,
+                          color = MaterialTheme.colorScheme.secondary,
+                          letterSpacing = 0.sp,
+                      ))
+              Spacer(modifier = Modifier.width(8.dp))
+              Icon(
+                  modifier = Modifier.size(20.dp).testTag("shoppingCartIcon"),
+                  imageVector = Icons.Filled.ShoppingCart,
+                  contentDescription = "Arrow icon",
+              )
+            }
+      }
 }
 
 /**

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receipt/ReceiptGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receipt/ReceiptGraph.kt
@@ -2,15 +2,14 @@ package com.github.se.assocify.ui.screens.treasury.receipt
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.github.se.assocify.model.database.AssociationAPI
-import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 
-fun NavGraphBuilder.receiptGraph(
-    navigationActions: NavigationActions,
-    userAPI: UserAPI,
-    associationAPI: AssociationAPI
-) {
-  composable(route = Destination.Receipt.route) { ReceiptScreen(navigationActions) }
+fun NavGraphBuilder.receiptGraph(navigationActions: NavigationActions) {
+  composable(route = Destination.NewReceipt.route) { ReceiptScreen(navigationActions) }
+  composable(Destination.EditReceipt("{receiptUid}").route) { backStackEntry ->
+    backStackEntry.arguments?.getString("receiptUid")?.let {
+      ReceiptScreen(navActions = navigationActions, receiptUid = it)
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receipt/ReceiptScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receipt/ReceiptScreen.kt
@@ -77,7 +77,7 @@ fun ReceiptScreen(
                   }
             })
       },
-      contentWindowInsets = WindowInsets(50.dp, 20.dp, 50.dp, 0.dp),
+      contentWindowInsets = WindowInsets(40.dp, 20.dp, 40.dp, 0.dp),
       snackbarHost = {
         SnackbarHost(
             hostState = receiptState.snackbarHostState,

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receipt/ReceiptViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receipt/ReceiptViewModel.kt
@@ -2,7 +2,7 @@ package com.github.se.assocify.ui.screens.treasury.receipt
 
 import androidx.compose.material3.SnackbarHostState
 import com.github.se.assocify.model.CurrentUser
-import com.github.se.assocify.model.database.ReceiptsAPI
+import com.github.se.assocify.model.database.ReceiptAPI
 import com.github.se.assocify.model.entities.Phase
 import com.github.se.assocify.model.entities.Receipt
 import com.github.se.assocify.navigation.NavigationActions
@@ -23,16 +23,17 @@ class ReceiptViewModel {
   private val NEW_RECEIPT_TITLE = "New Receipt"
   private val EDIT_RECEIPT_TITLE = "Edit Receipt"
 
-  private val receiptApi: ReceiptsAPI
+  private val receiptApi: ReceiptAPI
   private val navActions: NavigationActions
+  private val receiptUid: String
 
   private val _uiState: MutableStateFlow<ReceiptState>
   val uiState: StateFlow<ReceiptState>
 
   constructor(
       navActions: NavigationActions,
-      receiptApi: ReceiptsAPI =
-          ReceiptsAPI(
+      receiptApi: ReceiptAPI =
+          ReceiptAPI(
               userId = CurrentUser.userUid!!,
               basePath = "associations/" + CurrentUser.associationUid!!,
               storage = Firebase.storage,
@@ -40,6 +41,7 @@ class ReceiptViewModel {
   ) {
     this.navActions = navActions
     this.receiptApi = receiptApi
+    this.receiptUid = receiptApi.getNewId()
     _uiState = MutableStateFlow(ReceiptState(isNewReceipt = true, pageTitle = NEW_RECEIPT_TITLE))
     uiState = _uiState
   }
@@ -47,8 +49,8 @@ class ReceiptViewModel {
   constructor(
       receiptUid: String,
       navActions: NavigationActions,
-      receiptApi: ReceiptsAPI =
-          ReceiptsAPI(
+      receiptApi: ReceiptAPI =
+          ReceiptAPI(
               userId = CurrentUser.userUid!!,
               basePath = "associations/" + CurrentUser.associationUid!!,
               storage = Firebase.storage,
@@ -56,6 +58,7 @@ class ReceiptViewModel {
   ) {
     this.navActions = navActions
     this.receiptApi = receiptApi
+    this.receiptUid = receiptUid
     _uiState = MutableStateFlow(ReceiptState(isNewReceipt = false, pageTitle = EDIT_RECEIPT_TITLE))
     uiState = _uiState
 
@@ -144,7 +147,7 @@ class ReceiptViewModel {
 
     val receipt =
         Receipt(
-            uid = receiptApi.getNewId(),
+            uid = receiptUid,
             title = _uiState.value.title,
             description = _uiState.value.description,
             cents = PriceUtil.toCents(_uiState.value.amount),
@@ -181,7 +184,7 @@ class ReceiptViewModel {
       navActions.back()
     } else {
       receiptApi.deleteReceipt(
-          id = "",
+          id = receiptUid,
           onSuccess = { navActions.back() },
           onFailure = { _ ->
             CoroutineScope(Dispatchers.Main).launch {

--- a/app/src/main/java/com/github/se/assocify/ui/util/PriceUtil.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/util/PriceUtil.kt
@@ -97,6 +97,6 @@ object PriceUtil {
    * @return the string price
    */
   fun fromCents(cents: Int): String {
-    return (cents.toDouble() / 100).toString()
+    return "%.2f".format(cents.toDouble() / 100)
   }
 }

--- a/app/src/test/java/com/github/se/assocify/model/database/ReceiptsAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/ReceiptsAPITest.kt
@@ -39,7 +39,7 @@ class ReceiptsAPITest {
 
   @MockK lateinit var collectionReference: CollectionReference
 
-  private lateinit var api: ReceiptsAPI
+  private lateinit var api: ReceiptAPI
 
   private val successfulReceipt =
       Receipt(
@@ -82,8 +82,7 @@ class ReceiptsAPITest {
     mockkStatic(Log::class)
     every { Log.w(any(), any<String>()) }.returns(0)
 
-    api =
-        spyk<ReceiptsAPI>(ReceiptsAPI("uid", "aid", storage, firestore), recordPrivateCalls = true)
+    api = spyk<ReceiptAPI>(ReceiptAPI("uid", "aid", storage, firestore), recordPrivateCalls = true)
 
     every { api["parseReceiptList"](any<QuerySnapshot>()) } returns
         listOf(successfulReceipt, failingReceipt)

--- a/app/src/test/java/com/github/se/assocify/utils/PriceUtilTest.kt
+++ b/app/src/test/java/com/github/se/assocify/utils/PriceUtilTest.kt
@@ -73,7 +73,7 @@ class PriceUtilTest {
   @Test
   fun testFromCents() {
     val cents = 10000
-    val expected = "100.0"
+    val expected = "100.00"
     val actual = PriceUtil.fromCents(cents)
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
Makes sure the following actions work : 

- [x] Creating a receipt by clicking on the "add" button
- [x] Modifying an existing receipt by selecting it in the receipt tab
- [x] Deleting a receipt

Also some minor visual cleanup, and refactors ReceiptAPI