### PR TITLE
Set association uid to non empty string

### DIFF
--- a/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginViewModel.kt
@@ -18,7 +18,7 @@ class LoginViewModel(private val userAPI: UserAPI, private val navActions: Navig
   /** Updates the userId of the UI state */
   fun updateUser() {
     CurrentUser.userUid = getCurrentUser()!!.uid
-    CurrentUser.associationUid = ""
+    CurrentUser.associationUid = "associationUid"
     userAPI.getAllUsers(
         { users: List<User> ->
           val user = users.find { it.uid == getCurrentUser()!!.uid }


### PR DESCRIPTION
There was a problem when entering the treasury page because the association uid was set to an empty string. Since we don't have the relation between a user and multiple association, we can't fetch properly the associationuid from the db. I added another issue for later, when the relations will be implemented to fetch the association uid accordingly. 