### PR TITLE
Scrollable filter row

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
@@ -86,7 +89,9 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRow").assertIsDisplayed()
-      onNodeWithTag("filterRow").performScrollTo()
+      onNodeWithTag("filterRowDetailed").performTouchInput {
+        swipeLeft()
+      }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
@@ -77,6 +78,15 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
       // Verify the total is recalculated correctly
       val expectedTotal = 6000 // Sum of amounts for "Champachelor" and "Balelec"
       onNodeWithText("$expectedTotal").assertIsDisplayed()
+    }
+  }
+
+  /** Tests if filter row is scrollable */
+  @Test
+  fun testsIfFilterRowIsScrollable() {
+    with(composeTestRule) {
+      onNodeWithTag("filterRow").assertIsDisplayed()
+      onNodeWithTag("filterRow").performScrollTo()
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -5,9 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
@@ -89,9 +87,7 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRow").assertIsDisplayed()
-      onNodeWithTag("filterRowDetailed").performTouchInput {
-        swipeLeft()
-      }
+      onNodeWithTag("filterRowDetailed").performTouchInput { swipeLeft() }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -87,7 +87,7 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRow").assertIsDisplayed()
-      onNodeWithTag("filterRowDetailed").performTouchInput { swipeLeft() }
+      onNodeWithTag("filterRow").performTouchInput { swipeLeft() }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
@@ -138,7 +140,9 @@ class BalanceDetailedScreenTest :
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRowDetailed").assertIsDisplayed()
-      onNodeWithTag("filterRowDetailed").performScrollTo()
+        onNodeWithTag("filterRowDetailed").performTouchInput {
+            swipeLeft()
+        }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
@@ -129,6 +130,15 @@ class BalanceDetailedScreenTest :
 
       // Assert that budget lines not under "Unapproved" are not shown
       onNodeWithText("sweaters").assertDoesNotExist()
+    }
+  }
+
+  /** Tests if filter row is scrollable */
+  @Test
+  fun testsIfFilterRowIsScrollable() {
+    with(composeTestRule) {
+      onNodeWithTag("filterRowDetailed").assertIsDisplayed()
+      onNodeWithTag("filterRowDetailed").performScrollTo()
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -140,9 +139,7 @@ class BalanceDetailedScreenTest :
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRowDetailed").assertIsDisplayed()
-        onNodeWithTag("filterRowDetailed").performTouchInput {
-            swipeLeft()
-        }
+      onNodeWithTag("filterRowDetailed").performTouchInput { swipeLeft() }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -4,9 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
@@ -79,9 +77,7 @@ class BudgetDetailedScreenTest :
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRowDetailed").assertIsDisplayed()
-      onNodeWithTag("filterRowDetailed").performTouchInput {
-        swipeLeft()
-      }
+      onNodeWithTag("filterRowDetailed").performTouchInput { swipeLeft() }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
@@ -76,7 +79,9 @@ class BudgetDetailedScreenTest :
   fun testsIfFilterRowIsScrollable() {
     with(composeTestRule) {
       onNodeWithTag("filterRowDetailed").assertIsDisplayed()
-      onNodeWithTag("filterRowDetailed").performScrollTo()
+      onNodeWithTag("filterRowDetailed").performTouchInput {
+        swipeLeft()
+      }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
@@ -62,12 +63,20 @@ class BudgetDetailedScreenTest :
   /** Tests if the total amount correspond to the sum of the items */
   @Test
   fun testTotalAmount() {
-    // Test the accounting screen
     with(composeTestRule) {
       onNodeWithTag("totalItems").assertIsDisplayed()
       var total = 0
       budgetItems.forEach { total += it.amount }
       onNodeWithText(total.toString())
+    }
+  }
+
+  /** Tests if filter row is scrollable */
+  @Test
+  fun testsIfFilterRowIsScrollable() {
+    with(composeTestRule) {
+      onNodeWithTag("filterRowDetailed").assertIsDisplayed()
+      onNodeWithTag("filterRowDetailed").performScrollTo()
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -136,10 +135,6 @@ fun AccountingDetailedScreen(
         AccountingPage.BALANCE -> filteredBalanceList.sumOf { it.amount }
       }
 
-  // For scrollable filter row
-  val state = rememberScrollState()
-  LaunchedEffect(Unit) { state.animateScrollTo(100) }
-
   Scaffold(
       topBar = {
         CenterAlignedTopAppBar(
@@ -168,7 +163,7 @@ fun AccountingDetailedScreen(
             modifier = Modifier.fillMaxWidth().padding(innerPadding),
         ) {
           item {
-            Row(Modifier.testTag("filterRowDetailed").horizontalScroll(state)) {
+            Row(Modifier.testTag("filterRowDetailed").horizontalScroll(rememberScrollState())) {
               DropdownFilterChip(yearList.first(), yearList, "yearListTag") { selectedYear = it }
               if (page == AccountingPage.BALANCE) {
                 DropdownFilterChip(statusList.first(), statusList, "statusListTag") {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
@@ -1,12 +1,14 @@
 package com.github.se.assocify.ui.screens.treasury.accounting
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Help
@@ -23,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -133,6 +136,10 @@ fun AccountingDetailedScreen(
         AccountingPage.BALANCE -> filteredBalanceList.sumOf { it.amount }
       }
 
+  // For scrollable filter row
+  val state = rememberScrollState()
+  LaunchedEffect(Unit) { state.animateScrollTo(100) }
+
   Scaffold(
       topBar = {
         CenterAlignedTopAppBar(
@@ -161,7 +168,7 @@ fun AccountingDetailedScreen(
             modifier = Modifier.fillMaxWidth().padding(innerPadding),
         ) {
           item {
-            Row(Modifier.testTag("filterRowDetailed")) {
+            Row(Modifier.testTag("filterRowDetailed").horizontalScroll(state)) {
               DropdownFilterChip(yearList.first(), yearList, "yearListTag") { selectedYear = it }
               if (page == AccountingPage.BALANCE) {
                 DropdownFilterChip(statusList.first(), statusList, "statusListTag") {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,13 +69,9 @@ fun Accounting(
        subCategoryList
       else subCategoryList.filter { it.category.name == selectedCategory }
 
-  // For scrollable row
-  val state = rememberScrollState()
-  LaunchedEffect(Unit) { state.animateScrollTo(100) }
-
   LazyColumn(modifier = Modifier.fillMaxWidth().padding(25.dp).testTag("AccountingScreen")) {
     item {
-      Row(Modifier.testTag("filterRow").horizontalScroll(state)) {
+      Row(Modifier.testTag("filterRow").horizontalScroll(rememberScrollState())) {
         DropdownFilterChip(selectedYear, yearList, "yearFilterChip") { selectedYear = it }
         DropdownFilterChip(selectedCategory, categoryList.map { it.name }, "categoryFilterChip") {
           selectedCategory = it

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
@@ -1,17 +1,20 @@
 package com.github.se.assocify.ui.screens.treasury.accounting
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,9 +70,13 @@ fun Accounting(
        subCategoryList
       else subCategoryList.filter { it.category.name == selectedCategory }
 
+  // For scrollable row
+  val state = rememberScrollState()
+  LaunchedEffect(Unit) { state.animateScrollTo(100) }
+
   LazyColumn(modifier = Modifier.fillMaxWidth().padding(25.dp).testTag("AccountingScreen")) {
     item {
-      Row(Modifier.testTag("filterRow")) {
+      Row(Modifier.testTag("filterRow").horizontalScroll(state)) {
         DropdownFilterChip(selectedYear, yearList, "yearFilterChip") { selectedYear = it }
         DropdownFilterChip(selectedCategory, categoryList.map { it.name }, "categoryFilterChip") {
           selectedCategory = it


### PR DESCRIPTION
In Budget and balance sheet and budget and balance detailed sheet, the filter row wasn't scrollable. Thus, the filter chips weren't well displayed.