### PR TITLE
Repair Task API

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
 
 /**
  * API for interacting with the task table in the database.
@@ -103,16 +104,16 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
    * @param onFailure called on failure
    */
   fun editTask(
-      uid: String,
-      title: String,
-      description: String,
-      isCompleted: Boolean,
-      startTime: LocalDate,
-      peopleNeeded: Int,
-      category: String,
-      location: String,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
+    uid: String,
+    title: String,
+    description: String,
+    isCompleted: Boolean,
+    startTime: LocalDateTime,
+    peopleNeeded: Int,
+    category: String,
+    location: String,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
   ) {
     scope.launch {
       try {
@@ -133,6 +134,28 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
       }
     }
   }
+
+  /**
+   * Edits a task in the database.
+   *
+   * @param task the task to edit
+   * @param onSuccess called on success
+   * @param onFailure called on failure
+   */
+  fun editTask(task: Task, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    editTask(
+      task.uid,
+      task.title,
+      task.description,
+      task.isCompleted,
+      task.startTime,
+      task.peopleNeeded,
+      task.category,
+      task.location,
+      onSuccess,
+      onFailure)
+  }
+
   /**
    * Deletes a task from the database.
    *
@@ -178,7 +201,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
 
   @Serializable
   private data class SupabaseTask(
-      @SerialName("uid") val uid: String,
+      @SerialName("id") val uid: String,
       @SerialName("title") val title: String,
       @SerialName("description") val description: String,
       @SerialName("is_completed") val isCompleted: Boolean,
@@ -194,7 +217,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
           title = title,
           description = description,
           isCompleted = isCompleted,
-          startTime = LocalDate.parse(startTime),
+          startTime = LocalDateTime.parse(startTime),
           peopleNeeded = peopleNeeded,
           category = category,
           location = location,

--- a/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
@@ -3,13 +3,12 @@ package com.github.se.assocify.model.database
 import com.github.se.assocify.model.entities.Task
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
-import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.time.LocalDateTime
 
 /**
  * API for interacting with the task table in the database.
@@ -104,16 +103,16 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
    * @param onFailure called on failure
    */
   fun editTask(
-    uid: String,
-    title: String,
-    description: String,
-    isCompleted: Boolean,
-    startTime: LocalDateTime,
-    peopleNeeded: Int,
-    category: String,
-    location: String,
-    onSuccess: () -> Unit,
-    onFailure: (Exception) -> Unit
+      uid: String,
+      title: String,
+      description: String,
+      isCompleted: Boolean,
+      startTime: LocalDateTime,
+      peopleNeeded: Int,
+      category: String,
+      location: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
   ) {
     scope.launch {
       try {
@@ -144,16 +143,16 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
    */
   fun editTask(task: Task, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     editTask(
-      task.uid,
-      task.title,
-      task.description,
-      task.isCompleted,
-      task.startTime,
-      task.peopleNeeded,
-      task.category,
-      task.location,
-      onSuccess,
-      onFailure)
+        task.uid,
+        task.title,
+        task.description,
+        task.isCompleted,
+        task.startTime,
+        task.peopleNeeded,
+        task.category,
+        task.location,
+        onSuccess,
+        onFailure)
   }
 
   /**
@@ -217,7 +216,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
           title = title,
           description = description,
           isCompleted = isCompleted,
-          startTime = LocalDateTime.parse(startTime),
+          startTime = LocalDateTime.now(),
           peopleNeeded = peopleNeeded,
           category = category,
           location = location,

--- a/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
@@ -216,7 +216,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
           title = title,
           description = description,
           isCompleted = isCompleted,
-          startTime = LocalDateTime.now(),
+          startTime = LocalDateTime.parse(startTime),
           peopleNeeded = peopleNeeded,
           category = category,
           location = location,

--- a/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
@@ -3,7 +3,7 @@ package com.github.se.assocify.model.database
 import com.github.se.assocify.model.entities.Task
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -107,7 +107,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
       title: String,
       description: String,
       isCompleted: Boolean,
-      startTime: LocalDateTime,
+      startTime: OffsetDateTime,
       peopleNeeded: Int,
       category: String,
       location: String,
@@ -216,7 +216,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
           title = title,
           description = description,
           isCompleted = isCompleted,
-          startTime = LocalDateTime.parse(startTime),
+          startTime = OffsetDateTime.parse(startTime),
           peopleNeeded = peopleNeeded,
           category = category,
           location = location,

--- a/app/src/main/java/com/github/se/assocify/model/entities/Task.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Task.kt
@@ -1,6 +1,5 @@
 package com.github.se.assocify.model.entities
 
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 /**

--- a/app/src/main/java/com/github/se/assocify/model/entities/Task.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Task.kt
@@ -1,6 +1,6 @@
 package com.github.se.assocify.model.entities
 
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 /**
  * Data class representing a task that needs to be completed
@@ -20,7 +20,7 @@ data class Task(
     val title: String = "testName",
     val description: String = "description",
     val isCompleted: Boolean = false,
-    val startTime: LocalDateTime = LocalDateTime.now(),
+    val startTime: OffsetDateTime = OffsetDateTime.now(),
     val peopleNeeded: Int = 0,
     val category: String = "Committee",
     val location: String = "Here",

--- a/app/src/main/java/com/github/se/assocify/model/entities/Task.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Task.kt
@@ -1,6 +1,7 @@
 package com.github.se.assocify.model.entities
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * Data class representing a task that needs to be completed
@@ -20,7 +21,7 @@ data class Task(
     val title: String = "testName",
     val description: String = "description",
     val isCompleted: Boolean = false,
-    val startTime: LocalDate = LocalDate.now(),
+    val startTime: LocalDateTime = LocalDateTime.now(),
     val peopleNeeded: Int = 0,
     val category: String = "Committee",
     val location: String = "Here",

--- a/app/src/test/java/com/github/se/assocify/model/database/TaskAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/TaskAPITest.kt
@@ -163,14 +163,15 @@ class TaskAPITest {
     val onFailure: (Exception) -> Unit = mockk(relaxed = true)
     error = false
     taskAPI.editTask(
-        uuid1.toString(),
-        "newName",
-        "newDescription",
-        true,
-        OffsetDateTime.now(),
-        2,
-        "newCategory",
-        "newLocation",
+        Task(
+            uuid1.toString(),
+            "newName",
+            "newDescription",
+            true,
+            OffsetDateTime.now(),
+            2,
+            "newCategory",
+            "newLocation"),
         onSuccess) {
           fail("should not fail")
         }
@@ -178,14 +179,15 @@ class TaskAPITest {
 
     error = true
     taskAPI.editTask(
-        uuid1.toString(),
-        "newName",
-        "newDescription",
-        true,
-        OffsetDateTime.now(),
-        2,
-        "newCategory",
-        "newLocation",
+        Task(
+            uuid1.toString(),
+            "newName",
+            "newDescription",
+            true,
+            OffsetDateTime.now(),
+            2,
+            "newCategory",
+            "newLocation"),
         { fail("should not fail") },
         onFailure)
     verify(timeout = 1000) { onFailure(any()) }

--- a/app/src/test/java/com/github/se/assocify/model/database/TaskAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/TaskAPITest.kt
@@ -11,7 +11,7 @@ import io.mockk.junit4.MockKRule
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +31,7 @@ class TaskAPITest {
   private val uuid1: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
   private val uuid2: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
   private val uuid3: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+  private val responseTime = OffsetDateTime.now()
 
   private lateinit var taskAPI: TaskAPI
 
@@ -65,7 +66,7 @@ class TaskAPITest {
           "title": "testName",
           "description": "description",
           "is_completed": false,
-          "start_time": "2024-04-30 12:30:00" ,
+          "start_time": "$responseTime" ,
           "people_needed": 0,
           "category": "Committee",
           "location": "Here",
@@ -77,6 +78,7 @@ class TaskAPITest {
     taskAPI.getTask(uuid1.toString(), onSuccess, onFailure)
 
     verify(timeout = 1000) { onSuccess(any()) }
+
     verify(exactly = 0) { onFailure(any()) }
 
     // Test failure
@@ -100,7 +102,7 @@ class TaskAPITest {
             "title": "testName",
             "description": "description",
             "is_completed": false,
-            "start_time": "2024-04-30 12:30:00" ,
+            "start_time": "$responseTime" ,
             "people_needed": 0,
             "category": "Committee",
             "location": "Here",
@@ -111,7 +113,7 @@ class TaskAPITest {
             "title": "testName2",
             "description": "description2",
             "is_completed": false,
-            "start_time": "2024-04-30 12:30:00" ,
+            "start_time": "$responseTime",
             "people_needed": 2,
             "category": "Committee2",
             "location": "Here2",
@@ -165,7 +167,7 @@ class TaskAPITest {
         "newName",
         "newDescription",
         true,
-        LocalDateTime.now(),
+        OffsetDateTime.now(),
         2,
         "newCategory",
         "newLocation",
@@ -180,7 +182,7 @@ class TaskAPITest {
         "newName",
         "newDescription",
         true,
-        LocalDateTime.now(),
+        OffsetDateTime.now(),
         2,
         "newCategory",
         "newLocation",
@@ -216,7 +218,7 @@ class TaskAPITest {
             "title": "testName",
             "description": "description",
             "is_completed": false,
-            "start_time": "2024-04-30 12:30:00" ,
+            "start_time": "$responseTime" ,
             "people_needed": 0,
             "category": "Committee",
             "location": "Here",
@@ -227,7 +229,7 @@ class TaskAPITest {
             "title": "testName2",
             "description": "description2",
             "is_completed": false,
-            "start_time": "2024-04-30 12:30:00" ,
+            "start_time": "$responseTime" ,
             "people_needed": 2,
             "category": "Committee2",
             "location": "Here2",

--- a/app/src/test/java/com/github/se/assocify/model/database/TaskAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/TaskAPITest.kt
@@ -11,7 +11,7 @@ import io.mockk.junit4.MockKRule
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.Dispatchers
@@ -61,11 +61,11 @@ class TaskAPITest {
     response =
         """  
         {
-          "uid": "$uuid1"
+          "id": "$uuid1"
           "title": "testName",
           "description": "description",
           "is_completed": false,
-          "start_time": "2021-10-10",
+          "start_time": "2024-04-30 12:30:00" ,
           "people_needed": 0,
           "category": "Committee",
           "location": "Here",
@@ -96,22 +96,22 @@ class TaskAPITest {
         """
         [
           {
-            "uid": "$uuid1",
+            "id": "$uuid1",
             "title": "testName",
             "description": "description",
             "is_completed": false,
-            "start_time": "2021-10-10",
+            "start_time": "2024-04-30 12:30:00" ,
             "people_needed": 0,
             "category": "Committee",
             "location": "Here",
             "event_id": "eventUid"
           },
           {
-            "uid": "$uuid2",
+            "id": "$uuid2",
             "title": "testName2",
             "description": "description2",
             "is_completed": false,
-            "start_time": "2022-10-10",
+            "start_time": "2024-04-30 12:30:00" ,
             "people_needed": 2,
             "category": "Committee2",
             "location": "Here2",
@@ -165,7 +165,7 @@ class TaskAPITest {
         "newName",
         "newDescription",
         true,
-        LocalDate.now(),
+        LocalDateTime.now(),
         2,
         "newCategory",
         "newLocation",
@@ -180,7 +180,7 @@ class TaskAPITest {
         "newName",
         "newDescription",
         true,
-        LocalDate.now(),
+        LocalDateTime.now(),
         2,
         "newCategory",
         "newLocation",
@@ -212,22 +212,22 @@ class TaskAPITest {
         """
         [
           {
-            "uid": "$uuid1",
+            "id": "$uuid1",
             "title": "testName",
             "description": "description",
             "is_completed": false,
-            "start_time": "2021-10-10",
+            "start_time": "2024-04-30 12:30:00" ,
             "people_needed": 0,
             "category": "Committee",
             "location": "Here",
             "event_id": "eventUid"
           },
           {
-            "uid": "$uuid2",
+            "id": "$uuid2",
             "title": "testName2",
             "description": "description2",
             "is_completed": false,
-            "start_time": "2022-10-10",
+            "start_time": "2024-04-30 12:30:00" ,
             "people_needed": 2,
             "category": "Committee2",
             "location": "Here2",


### PR DESCRIPTION
Even if the tests of Task API passed, the database had problems detecting the Time format used locally. Thus I decided to modify the Task value so that it now uses a LocalDateTime which will make it easier to use it. 