### PR TITLE
Fix CI

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/LoginTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/LoginTest.kt
@@ -103,7 +103,7 @@ class LoginTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
       // assert that an Intent resolving to Google Mobile Services has been sent (for sign-in)
       intended(toPackage("com.google.android.gms"))
 
-      verify { navActions.onAuthError() }
+      verify(timeout = 1000) { navActions.onAuthError() }
       confirmVerified(navActions)
       assert(authError)
     }


### PR DESCRIPTION
Closes #212

One of the tests randomly failed in the CI. I believe it was because there was a mockk verification that didn't have a timeout, so if the threads didn't line up, it failed.

I wasn't able to test this locally; the test always passed.