### PR TITLE
Add a get for the current user's role in the current association

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -199,6 +199,27 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
     }
   }
 
+  /**
+   * Gets the current user's role in the current association
+   *
+   * @param onSuccess called on success with the current user's role in the association
+   * @param onFailure called on failure
+   */
+  fun getCurrentUserRole(onSuccess: (PermissionRole) -> Unit, onFailure: (Exception) -> Unit) {
+    tryAsync(onFailure) {
+      val membership =
+          db.from("member_role_association_view")
+              .select {
+                filter {
+                  Membership::userId eq CurrentUser.userUid!!
+                  Membership::associationId eq CurrentUser.associationUid!!
+                }
+              }
+              .decodeSingle<Membership>()
+      onSuccess(membership.getRole())
+    }
+  }
+
   @Serializable
   private data class Membership(
       @SerialName("user_id") val userId: String,

--- a/app/src/test/java/com/github/se/assocify/model/database/UserAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/UserAPITest.kt
@@ -3,6 +3,7 @@ package com.github.se.assocify.model.database
 import com.github.se.assocify.BuildConfig
 import com.github.se.assocify.model.entities.Association
 import com.github.se.assocify.model.entities.PermissionRole
+import com.github.se.assocify.model.entities.RoleType
 import com.github.se.assocify.model.entities.User
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
@@ -228,5 +229,37 @@ class UserAPITest {
     verify(timeout = 1000) {
       onSuccess(listOf(APITestUtils.PERMISSION_ROLE to APITestUtils.ASSOCIATION))
     }
+  }
+
+  @Test
+  fun testGetCurrentUserRole() {
+    val onSuccess: (PermissionRole) -> Unit = mockk(relaxed = true)
+
+    error = false
+    response =
+        """
+      [{
+        "user_id": "$uuid1",
+        "role_id": "$uuid1",
+        "association_id": "$uuid1",
+        "type": "presidency",
+        "association_name": "Test",
+        "association_description": "Test",
+        "association_creation_date": "2022-01-01"
+      }]
+    """
+            .trimIndent()
+    userAPI.getCurrentUserRole(onSuccess, { fail("Should not fail, failed with $it") })
+
+    verify(timeout = 1000) {
+      onSuccess(PermissionRole(uuid1.toString(), uuid1.toString(), RoleType.PRESIDENCY))
+    }
+
+    val onFailure: (Exception) -> Unit = mockk(relaxed = true)
+
+    error = true
+    userAPI.getCurrentUserRole({ fail("Should not succeed") }, onFailure)
+
+    verify(timeout = 1000) { onFailure(any()) }
   }
 }


### PR DESCRIPTION
This adds a way to get the current user's role in the current association. It is not very efficient, but we will add caching soon.