### PR TITLE
Profile : add the option to join another association

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/Epic4Test.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/Epic4Test.kt
@@ -38,8 +38,14 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * This test is an end-to-end test for the fourth epic :
+ *
+ * As a president of 2 associations, I want to register both in the app and chose in which one I
+ * currently want to work
+ */
 @RunWith(AndroidJUnit4::class)
-class EpicPrezTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
+class Epic4Test : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var navController: TestNavHostController
@@ -149,7 +155,7 @@ class EpicPrezTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
   }
 
   @Test
-  fun EpicPrezTest() {
+  fun Epic4Test() {
     with(composeTestRule) {
       // After login as uid "1", the user is in selectAsso :
       // check it's well displayed (no back arrow, no asso yet...)

--- a/app/src/androidTest/java/com/github/se/assocify/EpicPrezTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/EpicPrezTest.kt
@@ -1,0 +1,83 @@
+package com.github.se.assocify
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.assocify.model.database.AssociationAPI
+import com.github.se.assocify.model.database.BudgetAPI
+import com.github.se.assocify.model.database.EventAPI
+import com.github.se.assocify.model.database.TaskAPI
+import com.github.se.assocify.model.database.UserAPI
+import com.github.se.assocify.model.localsave.LoginSave
+import com.github.se.assocify.navigation.NavigationActions
+import com.kaspersky.components.composesupport.config.withComposeSupport
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EpicPrezTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var navController: TestNavHostController
+    private lateinit var navActions: NavigationActions
+
+    private val associationAPI = mockk<AssociationAPI>() {}
+
+    private val userAPI = mockk<UserAPI>() {}
+
+    private val eventAPI = mockk<EventAPI>() {}
+
+    private val taskAPI = mockk<TaskAPI>(relaxUnitFun = true)
+
+    private val budgetAPI = mockk<BudgetAPI>(relaxUnitFun = true)
+
+    private val loginSave = mockk<LoginSave>(relaxUnitFun = true)
+
+    @Before
+    fun testSetup() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            navActions = NavigationActions(navController, loginSave)
+
+            TestAssocifyApp(
+                navController, navActions, userAPI, associationAPI, eventAPI, budgetAPI, taskAPI)
+        }
+    }
+
+    @Test
+    fun EpicPrezTest() {
+        with(composeTestRule) {
+            // After login as uid "1", the user is in selectAsso :
+            // check it's well displayed (no back arrow...)
+
+
+            // As the president, they want to create their association1
+            // Goes to createAsso
+
+            // Fill all the fields with the association1 data (themselves as president + 1 treasury)
+
+            // Arrives at home screen with association1 as the current association
+
+            // Goes to the profile screen to check that and go to add their other association
+            // Click on join an other, arrives at selectAsso, goes to createAsso
+
+            // Fill all the fields with the association2 data (only themselves as president)
+
+            // Arrives back at profile with association2 as the current association
+
+            // CHeck that association2 is the current asso and that they can switch back to asso1
+
+        }
+
+    }
+}

--- a/app/src/androidTest/java/com/github/se/assocify/EpicPrezTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/EpicPrezTest.kt
@@ -1,22 +1,38 @@
 package com.github.se.assocify
 
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.model.database.EventAPI
 import com.github.se.assocify.model.database.TaskAPI
 import com.github.se.assocify.model.database.UserAPI
+import com.github.se.assocify.model.entities.Association
+import com.github.se.assocify.model.entities.PermissionRole
+import com.github.se.assocify.model.entities.RoleType
+import com.github.se.assocify.model.entities.User
 import com.github.se.assocify.model.localsave.LoginSave
+import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -24,60 +40,189 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class EpicPrezTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private lateinit var navController: TestNavHostController
-    private lateinit var navActions: NavigationActions
+  private lateinit var navController: TestNavHostController
+  private lateinit var navActions: NavigationActions
 
-    private val associationAPI = mockk<AssociationAPI>() {}
+  private val members =
+      listOf(
+          User("1", "jean"),
+          User("2", "roger"),
+          User("3", "marie"),
+      )
 
-    private val userAPI = mockk<UserAPI>() {}
+  private val placeholderAssociations =
+      listOf(
+          Association("a", "asso1", "desc1", LocalDate.EPOCH),
+          Association("b", "asso2", "desc2", LocalDate.EPOCH),
+      )
 
-    private val eventAPI = mockk<EventAPI>() {}
+  private var listAsso: List<Association> = emptyList()
 
-    private val taskAPI = mockk<TaskAPI>(relaxUnitFun = true)
+  private val associationAPI =
+      mockk<AssociationAPI>() {
+        every { getAssociations(any(), any()) } answers
+            {
+              val onSuccessCallback = firstArg<(List<Association>) -> Unit>()
+              onSuccessCallback.invoke(listAsso)
+            }
+        every { addAssociation(any(), any(), any()) } answers
+            {
+              val asso = firstArg<Association>()
 
-    private val budgetAPI = mockk<BudgetAPI>(relaxUnitFun = true)
+              if (asso.name == "asso1") {
+                CurrentUser.associationUid = placeholderAssociations[0].uid
+                listAsso = listAsso + placeholderAssociations[0]
+              } else if (asso.name == "asso2") {
+                CurrentUser.associationUid = placeholderAssociations[1].uid
+                listAsso = listAsso + placeholderAssociations[1]
+              }
 
-    private val loginSave = mockk<LoginSave>(relaxUnitFun = true)
+              navActions.goFromCreateAsso()
+            }
 
-    @Before
-    fun testSetup() {
-        composeTestRule.setContent {
-            navController = TestNavHostController(LocalContext.current)
-            navController.navigatorProvider.addNavigator(ComposeNavigator())
-            navActions = NavigationActions(navController, loginSave)
+        every { getAssociation("a", any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(Association) -> Unit>()
+              onSuccessCallback.invoke(listAsso[0])
+            }
 
-            TestAssocifyApp(
-                navController, navActions, userAPI, associationAPI, eventAPI, budgetAPI, taskAPI)
-        }
+        every { getAssociation("b", any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(Association) -> Unit>()
+              onSuccessCallback.invoke(listAsso[1])
+            }
+      }
+
+  private val userAPI =
+      mockk<UserAPI>() {
+        every { getUser("1", any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(User) -> Unit>()
+              onSuccessCallback.invoke(members[0])
+            }
+        every { getUser("2", any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(User) -> Unit>()
+              onSuccessCallback.invoke(members[1])
+            }
+        every { getAllUsers(any(), any()) } answers
+            {
+              val onSuccessCallback = firstArg<(List<User>) -> Unit>()
+              onSuccessCallback(members)
+            }
+        every { getCurrentUserAssociations(any(), any()) } answers
+            {
+              val onSuccessCallback = firstArg<(List<Association>) -> Unit>()
+              onSuccessCallback.invoke(listAsso)
+            }
+        every { getCurrentUserRole(any(), any()) } answers
+            {
+              val onSuccessCallback = firstArg<(PermissionRole) -> Unit>()
+              if (CurrentUser.associationUid == "a") {
+                onSuccessCallback.invoke(PermissionRole("1", "a", RoleType.PRESIDENCY))
+              } else {
+                onSuccessCallback.invoke(PermissionRole("1", "b", RoleType.PRESIDENCY))
+              }
+            }
+      }
+
+  private val eventAPI = mockk<EventAPI>() {}
+
+  private val taskAPI = mockk<TaskAPI>(relaxUnitFun = true)
+
+  private val budgetAPI = mockk<BudgetAPI>(relaxUnitFun = true)
+
+  private val loginSave = mockk<LoginSave>(relaxUnitFun = true)
+
+  @Before
+  fun testSetup() {
+    composeTestRule.setContent {
+      navController = TestNavHostController(LocalContext.current)
+      navController.navigatorProvider.addNavigator(ComposeNavigator())
+      navActions = NavigationActions(navController, loginSave)
+
+      TestAssocifyApp(
+          navController, navActions, userAPI, associationAPI, eventAPI, budgetAPI, taskAPI)
     }
+  }
 
-    @Test
-    fun EpicPrezTest() {
-        with(composeTestRule) {
-            // After login as uid "1", the user is in selectAsso :
-            // check it's well displayed (no back arrow...)
+  @Test
+  fun EpicPrezTest() {
+    with(composeTestRule) {
+      // After login as uid "1", the user is in selectAsso :
+      // check it's well displayed (no back arrow, no asso yet...)
+      onNodeWithTag("HelloText").assertTextContains("Hello jean !!").assertIsDisplayed()
+      onNodeWithTag("GoBackButton").assertDoesNotExist()
+      onNodeWithText("There are no associations to display.").assertIsDisplayed()
 
+      // As the president, they want to create their association1
+      // Goes to createAsso
+      onNodeWithTag("CreateNewOrganizationButton").assertIsDisplayed().performClick()
+      val toCreateAsso = navController.currentBackStackEntry?.destination?.route
+      assert(toCreateAsso == Destination.CreateAsso.route)
 
-            // As the president, they want to create their association1
-            // Goes to createAsso
+      // Fill all the fields with the association1 data (themselves as president + 1 treasury)
+      onNodeWithTag("name").performTextInput("asso1")
+      onNodeWithTag("addMember").performClick()
+      onNodeWithTag("memberSearchField").performClick().performTextInput("j")
+      onNodeWithTag("userDropdownItem-1").performClick() // jean
+      onNodeWithTag("role-PRESIDENCY").assertIsDisplayed().performClick()
+      onNodeWithTag("addMemberButton").performClick()
+      onNodeWithTag("addMember").performClick()
+      onNodeWithTag("memberSearchField").performClick().performTextInput("mar")
+      onNodeWithTag("userDropdownItem-3").performClick() // marie
+      onNodeWithTag("role-TREASURY").assertIsDisplayed().performClick()
+      onNodeWithTag("addMemberButton").performClick()
+      onNodeWithTag("create").assertHasClickAction().assertIsEnabled()
+      onNodeWithTag("create").performClick()
+      verify { associationAPI.addAssociation(any(), any(), any()) }
+      assert(listAsso.contains(placeholderAssociations[0]))
 
-            // Fill all the fields with the association1 data (themselves as president + 1 treasury)
+      // Arrives at home screen with association1 as the current association
+      val toHome = navController.currentBackStackEntry?.destination?.route
+      assert(toHome == Destination.Home.route)
+      onNodeWithTag("homeScreen").assertIsDisplayed()
 
-            // Arrives at home screen with association1 as the current association
+      // Goes to the profile screen to check that and go to add their other association
+      onNodeWithTag("mainNavBarItem/profile").assertIsDisplayed().performClick()
+      val toProfile = navController.currentBackStackEntry?.destination?.route
+      assert(toProfile == Destination.Profile.route)
 
-            // Goes to the profile screen to check that and go to add their other association
-            // Click on join an other, arrives at selectAsso, goes to createAsso
+      // Click on join an other
+      onNodeWithTag("associationDropdown").performClick()
+      onNodeWithTag("DropdownItem-join").performClick()
 
-            // Fill all the fields with the association2 data (only themselves as president)
+      // Arrives at selectAsso, goes to createAsso
+      val toSelectAssoFromProfile = navController.currentBackStackEntry?.destination?.route
+      assert(toSelectAssoFromProfile == Destination.SelectAsso.route)
+      onNodeWithTag("CreateNewOrganizationButton").assertIsDisplayed().performClick()
+      val toCreateAssoFromProfile = navController.currentBackStackEntry?.destination?.route
+      assert(toCreateAssoFromProfile == Destination.CreateAsso.route)
 
-            // Arrives back at profile with association2 as the current association
+      // Fill all the fields with the association2 data (only themselves as president)
+      onNodeWithTag("name").performTextInput("asso2")
+      onNodeWithTag("addMember").performClick()
+      onNodeWithTag("memberSearchField").performClick().performTextInput("j")
+      onNodeWithTag("userDropdownItem-1").performClick() // jean
+      onNodeWithTag("role-PRESIDENCY").assertIsDisplayed().performClick()
+      onNodeWithTag("addMemberButton").performClick()
+      onNodeWithTag("create").assertHasClickAction().assertIsEnabled()
+      onNodeWithTag("create").performClick()
+      verify { associationAPI.addAssociation(any(), any(), any()) }
+      assert(listAsso.contains(placeholderAssociations[1]))
 
-            // CHeck that association2 is the current asso and that they can switch back to asso1
+      // Arrives back at profile with association2 as the current association
+      val toProfileFromCreateAsso = navController.currentBackStackEntry?.destination?.route
+      assert(toProfileFromCreateAsso == Destination.Profile.route)
 
-        }
-
+      // Check that association2 is the current asso and that they can switch back to asso1
+      onNodeWithText("asso2").assertIsDisplayed()
+      onNodeWithTag("associationDropdown").performClick()
+      onNodeWithTag("DropdownItem-join").assertIsDisplayed()
+      onNodeWithTag("DropdownItem-a").performClick()
+      onNodeWithText("asso1").assertIsDisplayed()
     }
+  }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -92,9 +92,7 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   @Test
   fun testCreateNewOrganizationButton() {
     val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
-    composeTestRule.setContent {
-      SelectAssociationScreen(mockNavActions, model)
-    }
+    composeTestRule.setContent { SelectAssociationScreen(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       createOrgaButton {
         assertIsDisplayed()
@@ -112,9 +110,7 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
     CurrentUser.userUid = "testId"
     CurrentUser.associationUid = "testAssocId"
     val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
-    composeTestRule.setContent {
-      SelectAssociationScreen(mockNavActions, model)
-    }
+    composeTestRule.setContent { SelectAssociationScreen(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       searchOrganization { assertIsDisplayed() }
     }
@@ -124,9 +120,7 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   @Test
   fun testRegisteredOrganizationList() {
     val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
-    composeTestRule.setContent {
-      SelectAssociationScreen(mockNavActions, model)
-    }
+    composeTestRule.setContent { SelectAssociationScreen(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       registeredList {
         assertIsDisplayed()
@@ -150,9 +144,7 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
           onSuccessCallback(associations)
         }
     val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
-    composeTestRule.setContent {
-      SelectAssociationScreen(mockNavActions, model)
-    }
+    composeTestRule.setContent { SelectAssociationScreen(mockNavActions, model) }
     // Find the text node with the expected message and assert it is displayed
     composeTestRule.onNodeWithText("There are no organizations to display.").assertIsDisplayed()
   }
@@ -189,9 +181,7 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   @Test
   fun testSearchBarWorksWithNoResult() {
     val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
-    composeTestRule.setContent {
-      SelectAssociationScreen(mockNavActions, model)
-    }
+    composeTestRule.setContent { SelectAssociationScreen(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       // Checking initial state
       searchOrgaButton { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -16,7 +16,7 @@ import com.github.se.assocify.model.entities.Association
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.selectAssociation.DisplayOrganization
-import com.github.se.assocify.ui.screens.selectAssociation.SelectAssociation
+import com.github.se.assocify.ui.screens.selectAssociation.SelectAssociationScreen
 import com.github.se.assocify.ui.screens.selectAssociation.SelectAssociationViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
@@ -92,7 +92,9 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   /** This test checks if the "Create new organization" button is displayed */
   @Test
   fun testCreateNewOrganizationButton() {
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    composeTestRule.setContent {
+      SelectAssociationScreen(mockNavActions, mockAssocAPI, mockUserAPI)
+    }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       createOrgaButton {
         assertIsDisplayed()
@@ -110,7 +112,9 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   fun testSearchOrganization() {
     CurrentUser.userUid = "testId"
     CurrentUser.associationUid = "testAssocId"
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    composeTestRule.setContent {
+      SelectAssociationScreen(mockNavActions, mockAssocAPI, mockUserAPI)
+    }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       searchOrganization { assertIsDisplayed() }
     }
@@ -119,7 +123,9 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   /** This test checks if the registered organization list is correctly displayed */
   @Test
   fun testRegisteredOrganizationList() {
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    composeTestRule.setContent {
+      SelectAssociationScreen(mockNavActions, mockAssocAPI, mockUserAPI)
+    }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       registeredList {
         assertIsDisplayed()
@@ -142,7 +148,9 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
           val associations = emptyList<Association>()
           onSuccessCallback(associations)
         }
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    composeTestRule.setContent {
+      SelectAssociationScreen(mockNavActions, mockAssocAPI, mockUserAPI)
+    }
     // Find the text node with the expected message and assert it is displayed
     composeTestRule.onNodeWithText("There are no organizations to display.").assertIsDisplayed()
   }
@@ -178,7 +186,9 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   /* This test check if, when searching with the search bar the icons change */
   @Test
   fun testSearchBarWorksWithNoResult() {
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    composeTestRule.setContent {
+      SelectAssociationScreen(mockNavActions, mockAssocAPI, mockUserAPI)
+    }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       // Checking initial state
       searchOrgaButton { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -146,7 +146,7 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
     val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
     composeTestRule.setContent { SelectAssociationScreen(mockNavActions, model) }
     // Find the text node with the expected message and assert it is displayed
-    composeTestRule.onNodeWithText("There are no organizations to display.").assertIsDisplayed()
+    composeTestRule.onNodeWithText("There are no associations to display.").assertIsDisplayed()
   }
 
   /**

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -23,7 +23,6 @@ import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
-import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
@@ -104,7 +103,6 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
     }
     // assert: the nav action has been called
     verify { mockNavActions.navigateTo(Destination.CreateAsso) }
-    confirmVerified(mockNavActions)
   }
 
   /** This test checks if the search organization field is displayed */

--- a/app/src/main/java/com/github/se/assocify/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/assocify/navigation/NavigationActions.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify.navigation
 
+import android.annotation.SuppressLint
 import android.util.Log
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -62,5 +63,18 @@ class NavigationActions(
       return (it == Destination.Profile.route)
     }
     return false
+  }
+
+  @SuppressLint("RestrictedApi")
+  fun goBackFromCreateAsso() {
+    val maybeProfile = navController.currentBackStack.value.findLast {
+        it.destination.route == Destination.Profile.route
+      }
+
+    if (maybeProfile != null) {
+        navController.popBackStack(maybeProfile.destination.id, false)
+    } else {
+      onLogin(true)
+    }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/assocify/navigation/NavigationActions.kt
@@ -65,14 +65,20 @@ class NavigationActions(
     return false
   }
 
+  /**
+   * Navigation from the create association screen
+   *
+   * Goes either to home if it's after login or back to profile
+   */
   @SuppressLint("RestrictedApi")
-  fun goBackFromCreateAsso() {
-    val maybeProfile = navController.currentBackStack.value.findLast {
-        it.destination.route == Destination.Profile.route
-      }
+  fun goFromCreateAsso() {
+    val maybeProfile =
+        navController.currentBackStack.value.findLast {
+          it.destination.route == Destination.Profile.route
+        }
 
     if (maybeProfile != null) {
-        navController.popBackStack(maybeProfile.destination.id, false)
+      navController.popBackStack(maybeProfile.destination.id, false)
     } else {
       onLogin(true)
     }

--- a/app/src/main/java/com/github/se/assocify/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/assocify/navigation/NavigationActions.kt
@@ -52,4 +52,15 @@ class NavigationActions(
   fun back() {
     navController.popBackStack()
   }
+
+  /**
+   * Checks when the user is coming back from the select association screen if the previous screen
+   * was the profile screen
+   */
+  fun backFromSelectAsso(): Boolean {
+    navController.previousBackStackEntry?.destination?.route?.let {
+      return (it == Destination.Profile.route)
+    }
+    return false
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/composables/DropdownWithSetOptions.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/composables/DropdownWithSetOptions.kt
@@ -31,7 +31,6 @@ fun DropdownWithSetOptions(
     opened: Boolean,
     onOpenedChange: (Boolean) -> Unit,
     onSelectOption: (DropdownOption) -> Unit,
-    leadIcon: (@Composable () -> Unit)? = null,
 ) {
 
   ExposedDropdownMenuBox(
@@ -47,7 +46,7 @@ fun DropdownWithSetOptions(
               if (options.size > 1) ExposedDropdownMenuDefaults.TrailingIcon(expanded = opened)
             },
             modifier = Modifier.menuAnchor(),
-            leadingIcon = leadIcon)
+            leadingIcon = selectedOption.leadIcon)
 
         ExposedDropdownMenu(expanded = opened, onDismissRequest = { onOpenedChange(false) }) {
           options.forEach { item ->
@@ -57,7 +56,7 @@ fun DropdownWithSetOptions(
                   onSelectOption(item)
                   onOpenedChange(false)
                 },
-                leadingIcon = leadIcon,
+                leadingIcon = item.leadIcon,
                 modifier = Modifier.testTag("DropdownItem-${item.uid}"))
           }
         }
@@ -65,4 +64,8 @@ fun DropdownWithSetOptions(
 }
 
 /** An option for the dropdown : has a name (displayed) and a uid (for uniqueness) */
-data class DropdownOption(val name: String, val uid: String)
+data class DropdownOption(
+    val name: String,
+    val uid: String,
+    val leadIcon: (@Composable () -> Unit)? = null
+)

--- a/app/src/main/java/com/github/se/assocify/ui/composables/DropdownWithSetOptions.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/composables/DropdownWithSetOptions.kt
@@ -63,7 +63,10 @@ fun DropdownWithSetOptions(
       }
 }
 
-/** An option for the dropdown : has a name (displayed) and a uid (for uniqueness) */
+/**
+ * An option for the dropdown : a name (displayed), a uid (for uniqueness), a leading icon
+ * (optional, usually `{ Icon(...) }`, null by default)
+ */
 data class DropdownOption(
     val name: String,
     val uid: String,

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
@@ -47,7 +47,6 @@ import com.github.se.assocify.R
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.model.entities.RoleType
-import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.composables.UserSearchState
 import com.github.se.assocify.ui.composables.UserSearchTextField
@@ -141,10 +140,7 @@ fun CreateAssociationScreen(
                       Text("Add members")
                     }
                 Button(
-                    onClick = {
-                      viewmodel.saveAsso()
-                      navigationActions.navigateToMainTab(Destination.Home)
-                    },
+                    onClick = { viewmodel.saveAsso() },
                     modifier = Modifier.fillMaxWidth().testTag("create"),
                     enabled = state.savable) {
                       Text("Create")

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -31,7 +32,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -67,7 +67,7 @@ fun CreateAssociationScreen(
   Scaffold(
       modifier = Modifier.testTag("createAssoScreen"),
       topBar = {
-        TopAppBar(
+        CenterAlignedTopAppBar(
             modifier = Modifier.fillMaxWidth().testTag("TopAppBar"),
             navigationIcon = {
               IconButton(

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationViewmodel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationViewmodel.kt
@@ -175,7 +175,7 @@ class CreateAssociationViewmodel(
         onSuccess = {
           assoAPI.initAssociation(roles.values, _uiState.value.members, {}, {})
           CurrentUser.associationUid = association.uid
-          navActions.onLogin(true)
+          navActions.goFromCreateAsso()
         },
         onFailure = { exception ->
           Log.e("CreateAssoViewModel", "Failed to add asso: ${exception.message}")

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
@@ -144,14 +143,13 @@ fun ProfileScreen(navActions: NavigationActions, viewmodel: ProfileViewModel) {
               DropdownWithSetOptions(
                   options = state.myAssociations,
                   selectedOption =
-                      DropdownOption(state.selectedAssociation.name, state.selectedAssociation.uid),
+                      DropdownOption(
+                          state.selectedAssociation.name,
+                          state.selectedAssociation.uid,
+                          state.selectedAssociation.leadIcon),
                   opened = state.openAssociationDropdown,
                   onOpenedChange = { viewmodel.controlAssociationDropdown(it) },
                   onSelectOption = { viewmodel.setAssociation(it) },
-                  leadIcon = {
-                    Icon(
-                        imageVector = Icons.Default.People, contentDescription = "Association Logo")
-                  },
                   modifier =
                       Modifier.testTag("associationDropdown").align(Alignment.CenterHorizontally))
 

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
@@ -119,8 +119,8 @@ class ProfileViewModel(
   }
 
   /**
-   * This function is used to set the association of the user.
-   * It goes to selectAssociation screen if the user wants to join an other association.
+   * This function is used to set the association of the user. It goes to selectAssociation screen
+   * if the user wants to join an other association.
    *
    * @param association the association
    */

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
@@ -2,11 +2,13 @@ package com.github.se.assocify.ui.screens.profile
 
 import android.net.Uri
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GroupAdd
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.People
+import androidx.compose.material3.Icon
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -49,11 +51,24 @@ class ProfileViewModel(
           _uiState.value = _uiState.value.copy(myName = user.name, modifyingName = user.name)
         },
         { _uiState.value = _uiState.value.copy(myName = "name not found") })
+
     userAPI.getCurrentUserAssociations(
         { associations ->
           _uiState.value =
               _uiState.value.copy(
-                  myAssociations = associations.map { DropdownOption(it.name, it.uid) })
+                  myAssociations =
+                          associations.map {
+                            DropdownOption(
+                                it.name,
+                                it.uid,
+                                /* TODO fetch association logo, else by default :*/
+                                {
+                                  Icon(
+                                      imageVector = Icons.Default.People,
+                                      contentDescription = "Association Logo")
+                                })
+                          }
+                          + _uiState.value.myAssociations)
         },
         { _uiState.value = _uiState.value.copy(myAssociations = emptyList()) })
 
@@ -62,7 +77,16 @@ class ProfileViewModel(
         { association ->
           _uiState.value =
               _uiState.value.copy(
-                  selectedAssociation = DropdownOption(association.name, association.uid))
+                  selectedAssociation =
+                      DropdownOption(
+                          association.name,
+                          association.uid,
+                          /* TODO fetch association logo */
+                          {
+                            Icon(
+                                imageVector = Icons.Default.People,
+                                contentDescription = "Association Logo")
+                          }))
         },
         {
           _uiState.value =
@@ -182,11 +206,20 @@ data class ProfileUIState(
     // the uri of the profile image
     val profileImageURI: Uri? = null,
     // the associations of the user
-    val myAssociations: List<DropdownOption> = emptyList(),
+    val myAssociations: List<DropdownOption> =
+        listOf(
+            DropdownOption(
+                "Join an other",
+                "join",
+                {
+                  Icon(
+                      imageVector = Icons.Default.GroupAdd,
+                      contentDescription = "Join an other association")
+                })),
     // true if the association dropdown should be shown, false if should be hidden
     val openAssociationDropdown: Boolean = false,
-    // the selected (current) association - TODO idk what to do with the temporary association
-    val selectedAssociation: DropdownOption = DropdownOption("", "temp"),
+    // the selected (current) association
+    val selectedAssociation: DropdownOption = myAssociations[0],
     // current role of the user in the association
     val currentRole: PermissionRole =
         PermissionRole(CurrentUser.userUid!!, CurrentUser.associationUid!!, RoleType.MEMBER)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
@@ -120,10 +120,15 @@ class ProfileViewModel(
 
   /**
    * This function is used to set the association of the user.
+   * It goes to selectAssociation screen if the user wants to join an other association.
    *
    * @param association the association
    */
   fun setAssociation(association: DropdownOption) {
+    if (association.uid == "join") {
+      navActions.navigateTo(Destination.SelectAsso)
+      return
+    }
     CurrentUser.associationUid = association.uid
     _uiState.value = _uiState.value.copy(selectedAssociation = association)
     userAPI.getCurrentUserRole(

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
@@ -209,7 +209,7 @@ data class ProfileUIState(
     val myAssociations: List<DropdownOption> =
         listOf(
             DropdownOption(
-                "Join an other",
+                "Add association",
                 "join",
                 {
                   Icon(

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
@@ -57,18 +57,15 @@ class ProfileViewModel(
           _uiState.value =
               _uiState.value.copy(
                   myAssociations =
-                          associations.map {
-                            DropdownOption(
-                                it.name,
-                                it.uid,
-                                /* TODO fetch association logo, else by default :*/
-                                {
-                                  Icon(
-                                      imageVector = Icons.Default.People,
-                                      contentDescription = "Association Logo")
-                                })
-                          }
-                          + _uiState.value.myAssociations)
+                      associations.map {
+                        DropdownOption(it.name, it.uid)
+                        /* TODO fetch association logo, else by default :*/
+                        {
+                          Icon(
+                              imageVector = Icons.Default.People,
+                              contentDescription = "Association Logo")
+                        }
+                      } + _uiState.value.myAssociations)
         },
         { _uiState.value = _uiState.value.copy(myAssociations = emptyList()) })
 
@@ -78,15 +75,13 @@ class ProfileViewModel(
           _uiState.value =
               _uiState.value.copy(
                   selectedAssociation =
-                      DropdownOption(
-                          association.name,
-                          association.uid,
-                          /* TODO fetch association logo */
-                          {
-                            Icon(
-                                imageVector = Icons.Default.People,
-                                contentDescription = "Association Logo")
-                          }))
+                      DropdownOption(association.name, association.uid)
+                      /* TODO fetch association logo */
+                      {
+                        Icon(
+                            imageVector = Icons.Default.People,
+                            contentDescription = "Association Logo")
+                      })
         },
         {
           _uiState.value =

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationGraph.kt
@@ -13,7 +13,7 @@ fun NavGraphBuilder.selectAssociationGraph(
     associationAPI: AssociationAPI,
 ) {
   composable(route = Destination.SelectAsso.route) {
-    SelectAssociation(
+    SelectAssociationScreen(
         navActions = navigationActions, associationAPI = associationAPI, userAPI = userAPI)
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -123,8 +123,7 @@ fun SelectAssociationScreen(navActions: NavigationActions, viewModel: SelectAsso
                       imageVector = Icons.Default.Search,
                       contentDescription = null,
                       modifier =
-                          Modifier.clickable(
-                                      onClick = { viewModel.updateSearchQuery(query, true) })
+                          Modifier.clickable(onClick = { viewModel.updateSearchQuery(query, true) })
                               .testTag("SOB"))
                 }
               }) {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -2,7 +2,7 @@ package com.github.se.assocify.ui.screens.selectAssociation
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -16,9 +16,11 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -30,7 +32,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -60,79 +61,89 @@ fun SelectAssociation(
   Scaffold(
       modifier = Modifier.testTag("SelectAssociationScreen"),
       topBar = {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        CenterAlignedTopAppBar(
+            title = {
               Text(
                   modifier = Modifier.testTag("HelloText"),
                   text = "Hello " + state.value.user.name + " !!",
                   style = MaterialTheme.typography.headlineSmall)
-              SearchBar(
-                  modifier = Modifier.testTag("SearchOrganization"),
-                  query = query,
-                  onQueryChange = { query = it },
-                  onSearch = { model.updateSearchQuery(query, true) },
-                  onActiveChange = {},
-                  active = state.value.searchState,
-                  placeholder = { Text(text = "Search an organization") },
-                  trailingIcon = {
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navActions.navigateTo(Destination.Login) },
+                  modifier = Modifier.testTag("GoBackButton")) {
                     Icon(
-                        imageVector = Icons.Default.Clear,
-                        contentDescription = null,
-                        modifier =
-                            Modifier.clickable(
-                                onClick = {
-                                  model.updateSearchQuery("", false)
-                                  query = ""
-                                }))
-                  },
-                  leadingIcon = {
-                    if (state.value.searchState) {
-                      Icon(
-                          imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                          contentDescription = null,
-                          modifier =
-                              Modifier.clickable(
-                                      onClick = {
-                                        model.updateSearchQuery("", false)
-                                        query = ""
-                                      })
-                                  .testTag("ArrowBackButton"))
-                    } else {
-                      Icon(
-                          imageVector = Icons.Default.Search,
-                          contentDescription = null,
-                          modifier =
-                              Modifier.clickable(onClick = { model.updateSearchQuery(query, true) })
-                                  .testTag("SOB"))
-                    }
-                  }) {
-                    if (state.value.searchState) {
-                      val filteredAssos =
-                          state.value.associations.filter { ass ->
-                            val min = min(ass.name.length, state.value.searchQuery.length)
-                            ass.name.take(min).lowercase() ==
-                                state.value.searchQuery.take(min).lowercase()
-                          }
-                      filteredAssos.map { ass -> DisplayOrganization(ass, model) }
-                    } else {
-                      state.value.associations
-                    }
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back arrow",
+                    )
                   }
-            }
+            })
       },
       bottomBar = {
         Button(
             onClick = { navActions.navigateTo(Destination.CreateAsso) },
             modifier =
                 Modifier.fillMaxWidth().padding(16.dp).testTag("CreateNewOrganizationButton"),
-            content = { Text(text = "Create new organization") },
+            content = { Text(text = "Create new association") },
             colors =
                 ButtonDefaults.buttonColors(
                     contentColor = MaterialTheme.colorScheme.onPrimary,
                     containerColor = MaterialTheme.colorScheme.primary))
-      }) { innerPadding ->
+      },
+      contentWindowInsets = WindowInsets(20.dp, 10.dp, 20.dp, 20.dp)) { innerPadding ->
+        SearchBar(
+            modifier = Modifier.testTag("SearchOrganization").padding(innerPadding),
+            query = query,
+            onQueryChange = { query = it },
+            onSearch = { model.updateSearchQuery(query, true) },
+            onActiveChange = {},
+            active = state.value.searchState,
+            placeholder = { Text(text = "Search an association") },
+            trailingIcon = {
+              Icon(
+                  imageVector = Icons.Default.Clear,
+                  contentDescription = null,
+                  modifier =
+                      Modifier.clickable(
+                          onClick = {
+                            model.updateSearchQuery("", false)
+                            query = ""
+                          }))
+            },
+            leadingIcon = {
+              if (state.value.searchState) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = null,
+                    modifier =
+                        Modifier.clickable(
+                                onClick = {
+                                  model.updateSearchQuery("", false)
+                                  query = ""
+                                })
+                            .testTag("ArrowBackButton"))
+              } else {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    modifier =
+                        Modifier.clickable(onClick = { model.updateSearchQuery(query, true) })
+                            .testTag("SOB"))
+              }
+            }) {
+              if (state.value.searchState) {
+                val filteredAssos =
+                    state.value.associations.filter { ass ->
+                      val min = min(ass.name.length, state.value.searchQuery.length)
+                      ass.name.take(min).lowercase() ==
+                          state.value.searchQuery.take(min).lowercase()
+                    }
+                filteredAssos.map { ass -> DisplayOrganization(ass, model) }
+              } else {
+                state.value.associations
+              }
+            }
+
         LazyColumn(
             contentPadding = innerPadding,
             verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -156,7 +156,7 @@ fun SelectAssociationScreen(
                 // Display only registered organization
                 val registeredAssociation = state.value.associations
                 if (registeredAssociation.isEmpty()) {
-                  item { Text(text = "There are no organizations to display.") }
+                  item { Text(text = "There are no associations to display.") }
                 } else {
                   itemsIndexed(registeredAssociation) { index, organization ->
                     DisplayOrganization(organization, model)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -70,7 +70,7 @@ fun SelectAssociation(
             },
             navigationIcon = {
               IconButton(
-                  onClick = { navActions.navigateTo(Destination.Login) },
+                  onClick = { navActions.back() },
                   modifier = Modifier.testTag("GoBackButton")) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -141,7 +141,6 @@ fun SelectAssociationScreen(navActions: NavigationActions, viewModel: SelectAsso
               }
 
           LazyColumn(
-              //            contentPadding = innerPadding,
               verticalArrangement = Arrangement.spacedBy(4.dp),
               modifier =
                   Modifier.fillMaxSize().fillMaxWidth().padding(16.dp).testTag("RegisteredList")) {

--- a/app/src/test/java/com/github/se/assocify/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/assocify/navigation/NavigationActionsTest.kt
@@ -61,4 +61,12 @@ class NavigationActionsTest {
 
     verify { navController.popBackStack() }
   }
+
+  @Test
+  fun `navigate back from SelectAsso to Profile`() {
+    navigationActions.navigateTo(Destination.Profile)
+    navigationActions.navigateTo(Destination.SelectAsso)
+    navigationActions.backFromSelectAsso()
+    verify { navController.navigate(Destination.Profile.route) }
+  }
 }


### PR DESCRIPTION
Currently, the only way to join an association is when you first register in the app and if someone else adds you in their association when creating it. The goal of this PR is to add a way to join another association, from the profile.

- [x] Add button to profile
- [x] Button goes to selectAsso
- [x] Can go back to profile
- [x] CurrentAsso is the one you just joined (/created)
- [x] Tests