### PR TITLE
BugFix: Multiple Reload

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -19,16 +19,17 @@ import com.github.se.assocify.model.entities.Status
 import com.github.se.assocify.model.entities.TVA
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.balance.BalanceDetailedScreen
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetDetailedViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
-import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDate
 
 @RunWith(AndroidJUnit4::class)
 class BalanceDetailedScreenTest :
@@ -89,8 +90,10 @@ class BalanceDetailedScreenTest :
   fun setup() {
     CurrentUser.userUid = "userId"
     CurrentUser.associationUid = "associationId"
+    val subCategoryUid = "subcategoryuid"
+    val budgetDetailedViewModel = BudgetDetailedViewModel( mockBudgetAPI, subCategoryUid)
     composeTestRule.setContent {
-      BalanceDetailedScreen("subcategoryuid", mockNavActions, mockBudgetAPI)
+      BalanceDetailedScreen(subCategoryUid, mockNavActions, budgetDetailedViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -25,11 +25,11 @@ import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDate
 
 @RunWith(AndroidJUnit4::class)
 class BalanceDetailedScreenTest :
@@ -91,7 +91,7 @@ class BalanceDetailedScreenTest :
     CurrentUser.userUid = "userId"
     CurrentUser.associationUid = "associationId"
     val subCategoryUid = "subcategoryuid"
-    val budgetDetailedViewModel = BudgetDetailedViewModel( mockBudgetAPI, subCategoryUid)
+    val budgetDetailedViewModel = BudgetDetailedViewModel(mockBudgetAPI, subCategoryUid)
     composeTestRule.setContent {
       BalanceDetailedScreen(subCategoryUid, mockNavActions, budgetDetailedViewModel)
     }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -72,7 +72,7 @@ class BudgetDetailedScreenTest :
     CurrentUser.associationUid = "associationId"
     budgetDetailedViewModel = BudgetDetailedViewModel(mockBudgetAPI, "subCategoryUid")
     composeTestRule.setContent {
-      BudgetDetailedScreen("subCategoryUid", mockNavActions, mockBudgetAPI)
+      BudgetDetailedScreen("subCategoryUid", mockNavActions, budgetDetailedViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
@@ -62,9 +62,7 @@ class CreateAssoScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   @Before
   fun setup() {
     CurrentUser.userUid = "1"
-    composeTestRule.setContent {
-      CreateAssociationScreen(mockNavActions, bigView)
-    }
+    composeTestRule.setContent { CreateAssociationScreen(mockNavActions, bigView) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/CreateAssoScreenTest.kt
@@ -63,7 +63,7 @@ class CreateAssoScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   fun setup() {
     CurrentUser.userUid = "1"
     composeTestRule.setContent {
-      CreateAssociationScreen(mockNavActions, mockAssocAPI, mockUserAPI, bigView)
+      CreateAssociationScreen(mockNavActions, bigView)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/assocify/screens/LoginTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/LoginTest.kt
@@ -27,11 +27,11 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDate
 
 @RunWith(AndroidJUnit4::class)
 class LoginTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {

--- a/app/src/androidTest/java/com/github/se/assocify/screens/LoginTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/LoginTest.kt
@@ -27,11 +27,11 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDate
 
 @RunWith(AndroidJUnit4::class)
 class LoginTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
@@ -69,7 +69,7 @@ class LoginTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
           val onSuccess = firstArg<(List<User>) -> Unit>()
           onSuccess(listOf()) // instantiate with a empty list: just to test login
         }
-    composeTestRule.setContent { LoginScreen(navActions, userAPI, viewmodel) }
+    composeTestRule.setContent { LoginScreen(navActions, viewmodel) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
@@ -29,11 +29,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
+import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
@@ -301,10 +301,7 @@ class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   fun testSetup() {
     CurrentUser.userUid = "testUser"
     CurrentUser.associationUid = "testUser"
-    composeTestRule.setContent {
-      ReceiptScreen(
-          viewModel = viewModel)
-    }
+    composeTestRule.setContent { ReceiptScreen(viewModel = viewModel) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
@@ -29,11 +29,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
-import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
@@ -74,7 +74,7 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   fun testSetup() {
     CurrentUser.userUid = "testUser"
     CurrentUser.associationUid = "testAssociation"
-    composeTestRule.setContent { ReceiptScreen(navActions = navActions, viewModel = viewModel) }
+    composeTestRule.setContent { ReceiptScreen(viewModel = viewModel) }
   }
 
   @Test
@@ -303,8 +303,6 @@ class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
     CurrentUser.associationUid = "testUser"
     composeTestRule.setContent {
       ReceiptScreen(
-          receiptUid = "08a11dc8-975c-4da1-93a6-865c20c7adec",
-          navActions = navActions,
           viewModel = viewModel)
     }
   }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -28,11 +28,11 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.verify
-import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDate
 
 /**
  * This class represents the SelectAssociationScreen
@@ -92,7 +92,8 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   /** This test checks if the "Create new organization" button is displayed */
   @Test
   fun testCreateNewOrganizationButton() {
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
+    composeTestRule.setContent { SelectAssociation(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       createOrgaButton {
         assertIsDisplayed()
@@ -110,7 +111,8 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   fun testSearchOrganization() {
     CurrentUser.userUid = "testId"
     CurrentUser.associationUid = "testAssocId"
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
+    composeTestRule.setContent { SelectAssociation(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       searchOrganization { assertIsDisplayed() }
     }
@@ -119,7 +121,8 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   /** This test checks if the registered organization list is correctly displayed */
   @Test
   fun testRegisteredOrganizationList() {
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
+    composeTestRule.setContent { SelectAssociation(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       registeredList {
         assertIsDisplayed()
@@ -142,7 +145,8 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
           val associations = emptyList<Association>()
           onSuccessCallback(associations)
         }
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
+    composeTestRule.setContent { SelectAssociation(mockNavActions, model) }
     // Find the text node with the expected message and assert it is displayed
     composeTestRule.onNodeWithText("There are no organizations to display.").assertIsDisplayed()
   }
@@ -178,7 +182,8 @@ class SelectAssociationTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   /* This test check if, when searching with the search bar the icons change */
   @Test
   fun testSearchBarWorksWithNoResult() {
-    composeTestRule.setContent { SelectAssociation(mockNavActions, mockAssocAPI, mockUserAPI) }
+    val model = SelectAssociationViewModel(mockAssocAPI, mockUserAPI, mockNavActions)
+    composeTestRule.setContent { SelectAssociation(mockNavActions, model) }
     ComposeScreen.onComposeScreen<SelectAssociationScreenTest>(composeTestRule) {
       // Checking initial state
       searchOrgaButton { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/SelectAssociationScreenTest.kt
@@ -28,11 +28,11 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.verify
+import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDate
 
 /**
  * This class represents the SelectAssociationScreen

--- a/app/src/androidTest/java/com/github/se/assocify/screens/TreasuryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/TreasuryScreenTest.kt
@@ -13,6 +13,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.TreasuryScreen
+import com.github.se.assocify.ui.screens.treasury.TreasuryViewModel
+import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -36,7 +38,9 @@ class TreasuryScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCom
     every { navActions.navigateTo(any()) } answers {}
     CurrentUser.userUid = "testUser"
     CurrentUser.associationUid = "testAssociation"
-    composeTestRule.setContent { TreasuryScreen(navActions) }
+    val receiptListViewModel = ReceiptListViewModel(navActions)
+    val viewModel = TreasuryViewModel(navActions, receiptListViewModel)
+    composeTestRule.setContent { TreasuryScreen(navActions, receiptListViewModel, viewModel) }
   }
 
   @Test

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationGraph.kt
@@ -13,6 +13,9 @@ fun NavGraphBuilder.createAssociationGraph(
     associationAPI: AssociationAPI
 ) {
   composable(route = Destination.CreateAsso.route) {
-    CreateAssociationScreen(navigationActions, associationAPI, userAPI)
+    CreateAssociationScreen(
+        navigationActions,
+        CreateAssociationViewmodel(associationAPI, userAPI, navigationActions)
+    )
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationGraph.kt
@@ -14,8 +14,6 @@ fun NavGraphBuilder.createAssociationGraph(
 ) {
   composable(route = Destination.CreateAsso.route) {
     CreateAssociationScreen(
-        navigationActions,
-        CreateAssociationViewmodel(associationAPI, userAPI, navigationActions)
-    )
+        navigationActions, CreateAssociationViewmodel(associationAPI, userAPI, navigationActions))
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
@@ -44,8 +44,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.github.se.assocify.R
-import com.github.se.assocify.model.database.AssociationAPI
-import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.model.entities.RoleType
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
@@ -56,10 +54,8 @@ import com.github.se.assocify.ui.composables.UserSearchTextField
 @Composable
 fun CreateAssociationScreen(
     navigationActions: NavigationActions,
-    assoAPI: AssociationAPI,
-    userAPI: UserAPI,
-    viewmodel: CreateAssociationViewmodel =
-        CreateAssociationViewmodel(assoAPI, userAPI, navigationActions)
+    viewmodel: CreateAssociationViewmodel
+
 ) {
 
   val state by viewmodel.uiState.collectAsState()

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
@@ -55,7 +55,6 @@ import com.github.se.assocify.ui.composables.UserSearchTextField
 fun CreateAssociationScreen(
     navigationActions: NavigationActions,
     viewmodel: CreateAssociationViewmodel
-
 ) {
 
   val state by viewmodel.uiState.collectAsState()

--- a/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginGraph.kt
@@ -11,6 +11,6 @@ fun NavGraphBuilder.loginGraph(
     userAPI: UserAPI,
 ) {
   composable(route = Destination.Login.route) {
-      LoginScreen(navigationActions, LoginViewModel(navigationActions, userAPI))
+    LoginScreen(navigationActions, LoginViewModel(navigationActions, userAPI))
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginGraph.kt
@@ -10,5 +10,7 @@ fun NavGraphBuilder.loginGraph(
     navigationActions: NavigationActions,
     userAPI: UserAPI,
 ) {
-  composable(route = Destination.Login.route) { LoginScreen(navigationActions, userAPI) }
+  composable(route = Destination.Login.route) {
+      LoginScreen(navigationActions, LoginViewModel(navigationActions, userAPI))
+  }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginScreen.kt
@@ -70,10 +70,7 @@ fun rememberSupabaseAuthLauncher(
 }
 
 @Composable
-fun LoginScreen(
-    navActions: NavigationActions,
-    viewModel: LoginViewModel
-) {
+fun LoginScreen(navActions: NavigationActions, viewModel: LoginViewModel) {
 
   val launcher =
       rememberSupabaseAuthLauncher(

--- a/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/login/LoginScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.assocify.R
 import com.github.se.assocify.model.SupabaseClient
-import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.navigation.NavigationActions
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
@@ -73,8 +72,7 @@ fun rememberSupabaseAuthLauncher(
 @Composable
 fun LoginScreen(
     navActions: NavigationActions,
-    userAPI: UserAPI,
-    viewModel: LoginViewModel = LoginViewModel(navActions, userAPI)
+    viewModel: LoginViewModel
 ) {
 
   val launcher =

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationGraph.kt
@@ -14,6 +14,7 @@ fun NavGraphBuilder.selectAssociationGraph(
 ) {
   composable(route = Destination.SelectAsso.route) {
     SelectAssociation(
-        navActions = navigationActions, associationAPI = associationAPI, userAPI = userAPI)
+        navigationActions,
+        SelectAssociationViewModel(associationAPI, userAPI, navigationActions))
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationGraph.kt
@@ -14,7 +14,6 @@ fun NavGraphBuilder.selectAssociationGraph(
 ) {
   composable(route = Destination.SelectAsso.route) {
     SelectAssociation(
-        navigationActions,
-        SelectAssociationViewModel(associationAPI, userAPI, navigationActions))
+        navigationActions, SelectAssociationViewModel(associationAPI, userAPI, navigationActions))
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -46,10 +46,7 @@ import kotlin.math.min
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SelectAssociation(
-    navActions: NavigationActions,
-    viewModel: SelectAssociationViewModel
-) {
+fun SelectAssociation(navActions: NavigationActions, viewModel: SelectAssociationViewModel) {
   val state = viewModel.uiState.collectAsState()
   var query by remember { mutableStateOf("") }
 
@@ -100,7 +97,8 @@ fun SelectAssociation(
                           imageVector = Icons.Default.Search,
                           contentDescription = null,
                           modifier =
-                              Modifier.clickable(onClick = { viewModel.updateSearchQuery(query, true) })
+                              Modifier.clickable(
+                                      onClick = { viewModel.updateSearchQuery(query, true) })
                                   .testTag("SOB"))
                     }
                   }) {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/selectAssociation/SelectAssociationScreen.kt
@@ -34,8 +34,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.se.assocify.model.database.AssociationAPI
-import com.github.se.assocify.model.database.UserAPI
 import com.github.se.assocify.model.entities.Association
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
@@ -50,11 +48,9 @@ import kotlin.math.min
 @Composable
 fun SelectAssociation(
     navActions: NavigationActions,
-    associationAPI: AssociationAPI,
-    userAPI: UserAPI
+    viewModel: SelectAssociationViewModel
 ) {
-  val model = SelectAssociationViewModel(associationAPI, userAPI, navActions)
-  val state = model.uiState.collectAsState()
+  val state = viewModel.uiState.collectAsState()
   var query by remember { mutableStateOf("") }
 
   Scaffold(
@@ -72,7 +68,7 @@ fun SelectAssociation(
                   modifier = Modifier.testTag("SearchOrganization"),
                   query = query,
                   onQueryChange = { query = it },
-                  onSearch = { model.updateSearchQuery(query, true) },
+                  onSearch = { viewModel.updateSearchQuery(query, true) },
                   onActiveChange = {},
                   active = state.value.searchState,
                   placeholder = { Text(text = "Search an organization") },
@@ -83,7 +79,7 @@ fun SelectAssociation(
                         modifier =
                             Modifier.clickable(
                                 onClick = {
-                                  model.updateSearchQuery("", false)
+                                  viewModel.updateSearchQuery("", false)
                                   query = ""
                                 }))
                   },
@@ -95,7 +91,7 @@ fun SelectAssociation(
                           modifier =
                               Modifier.clickable(
                                       onClick = {
-                                        model.updateSearchQuery("", false)
+                                        viewModel.updateSearchQuery("", false)
                                         query = ""
                                       })
                                   .testTag("ArrowBackButton"))
@@ -104,7 +100,7 @@ fun SelectAssociation(
                           imageVector = Icons.Default.Search,
                           contentDescription = null,
                           modifier =
-                              Modifier.clickable(onClick = { model.updateSearchQuery(query, true) })
+                              Modifier.clickable(onClick = { viewModel.updateSearchQuery(query, true) })
                                   .testTag("SOB"))
                     }
                   }) {
@@ -115,7 +111,7 @@ fun SelectAssociation(
                             ass.name.take(min).lowercase() ==
                                 state.value.searchQuery.take(min).lowercase()
                           }
-                      filteredAssos.map { ass -> DisplayOrganization(ass, model) }
+                      filteredAssos.map { ass -> DisplayOrganization(ass, viewModel) }
                     } else {
                       state.value.associations
                     }
@@ -144,7 +140,7 @@ fun SelectAssociation(
                 item { Text(text = "There are no organizations to display.") }
               } else {
                 itemsIndexed(registeredAssociation) { index, organization ->
-                  DisplayOrganization(organization, model)
+                  DisplayOrganization(organization, viewModel)
                   // Add a Divider for each organization except the last one
                   if (index < registeredAssociation.size - 1) {
                     HorizontalDivider(Modifier.fillMaxWidth().padding(8.dp))

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
@@ -8,13 +8,17 @@ import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.balance.balanceDetailedGraph
 import com.github.se.assocify.ui.screens.treasury.accounting.budget.budgetDetailedGraph
 import com.github.se.assocify.ui.screens.treasury.accounting.newcategory.addAccountingCategory
+import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewModel
 import com.github.se.assocify.ui.screens.treasury.receiptstab.receipt.receiptGraph
 
 fun NavGraphBuilder.treasuryGraph(navigationActions: NavigationActions, budgetAPI: BudgetAPI) {
   composable(
       route = Destination.Treasury.route,
   ) {
-    TreasuryScreen(navigationActions)
+    val receiptListViewModel = ReceiptListViewModel(navigationActions)
+    TreasuryScreen(navigationActions,
+      receiptListViewModel,
+      TreasuryViewModel(navActions = navigationActions, receiptListViewModel = receiptListViewModel))
   }
   receiptGraph(navigationActions)
   budgetDetailedGraph(navigationActions, budgetAPI)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
@@ -16,9 +16,11 @@ fun NavGraphBuilder.treasuryGraph(navigationActions: NavigationActions, budgetAP
       route = Destination.Treasury.route,
   ) {
     val receiptListViewModel = ReceiptListViewModel(navigationActions)
-    TreasuryScreen(navigationActions,
-      receiptListViewModel,
-      TreasuryViewModel(navActions = navigationActions, receiptListViewModel = receiptListViewModel))
+    TreasuryScreen(
+        navigationActions,
+        receiptListViewModel,
+        TreasuryViewModel(
+            navActions = navigationActions, receiptListViewModel = receiptListViewModel))
   }
   receiptGraph(navigationActions)
   budgetDetailedGraph(navigationActions, budgetAPI)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
@@ -42,9 +42,8 @@ import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewMod
 @Composable
 fun TreasuryScreen(
     navActions: NavigationActions,
-    receiptListViewModel: ReceiptListViewModel = ReceiptListViewModel(navActions),
-    treasuryViewModel: TreasuryViewModel =
-        TreasuryViewModel(navActions = navActions, receiptListViewModel = receiptListViewModel)
+    receiptListViewModel: ReceiptListViewModel,
+    treasuryViewModel: TreasuryViewModel
 ) {
 
   val treasuryState by treasuryViewModel.uiState.collectAsState()

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/balance/BalanceDetailedGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/balance/BalanceDetailedGraph.kt
@@ -13,7 +13,8 @@ fun NavGraphBuilder.balanceDetailedGraph(
 ) {
   composable(Destination.BalanceDetailed("{subCategoryUid}").route) { backStackEntry ->
     backStackEntry.arguments?.getString("subCategoryUid")?.let {
-      BalanceDetailedScreen(subCategoryUid = it, navigationActions, BudgetDetailedViewModel(budgetAPI, it))
+      BalanceDetailedScreen(
+          subCategoryUid = it, navigationActions, BudgetDetailedViewModel(budgetAPI, it))
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/balance/BalanceDetailedGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/balance/BalanceDetailedGraph.kt
@@ -5,6 +5,7 @@ import androidx.navigation.compose.composable
 import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetDetailedViewModel
 
 fun NavGraphBuilder.balanceDetailedGraph(
     navigationActions: NavigationActions,
@@ -12,7 +13,7 @@ fun NavGraphBuilder.balanceDetailedGraph(
 ) {
   composable(Destination.BalanceDetailed("{subCategoryUid}").route) { backStackEntry ->
     backStackEntry.arguments?.getString("subCategoryUid")?.let {
-      BalanceDetailedScreen(subCategoryUid = it, navigationActions, budgetAPI = budgetAPI)
+      BalanceDetailedScreen(subCategoryUid = it, navigationActions, BudgetDetailedViewModel(budgetAPI, it))
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/balance/BalanceDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/balance/BalanceDetailedScreen.kt
@@ -1,7 +1,6 @@
 package com.github.se.assocify.ui.screens.treasury.accounting.balance
 
 import androidx.compose.runtime.Composable
-import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingDetailedScreen
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingPage
@@ -18,11 +17,11 @@ import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetDetail
 fun BalanceDetailedScreen(
     subCategoryUid: String,
     navigationActions: NavigationActions,
-    budgetAPI: BudgetAPI
+    budgetDetailedViewModel: BudgetDetailedViewModel
 ) {
   AccountingDetailedScreen(
       page = AccountingPage.BALANCE,
       subCategoryUid = subCategoryUid,
       navigationActions = navigationActions,
-      budgetDetailedViewModel = BudgetDetailedViewModel(budgetAPI, subCategoryUid))
+      budgetDetailedViewModel = budgetDetailedViewModel)
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedGraph.kt
@@ -12,7 +12,7 @@ fun NavGraphBuilder.budgetDetailedGraph(
 ) {
   composable(Destination.BudgetDetailed("{subCategoryUid}").route) { backStackEntry ->
     backStackEntry.arguments?.getString("subCategoryUid")?.let {
-      BudgetDetailedScreen(subCategoryUid = it, navigationActions, budgetAPI)
+      BudgetDetailedScreen(subCategoryUid = it, navigationActions, BudgetDetailedViewModel(budgetAPI, it))
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedGraph.kt
@@ -12,7 +12,8 @@ fun NavGraphBuilder.budgetDetailedGraph(
 ) {
   composable(Destination.BudgetDetailed("{subCategoryUid}").route) { backStackEntry ->
     backStackEntry.arguments?.getString("subCategoryUid")?.let {
-      BudgetDetailedScreen(subCategoryUid = it, navigationActions, BudgetDetailedViewModel(budgetAPI, it))
+      BudgetDetailedScreen(
+          subCategoryUid = it, navigationActions, BudgetDetailedViewModel(budgetAPI, it))
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedScreen.kt
@@ -1,7 +1,6 @@
 package com.github.se.assocify.ui.screens.treasury.accounting.budget
 
 import androidx.compose.runtime.Composable
-import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingDetailedScreen
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingPage
@@ -18,9 +17,7 @@ import com.github.se.assocify.ui.screens.treasury.accounting.AccountingPage
 fun BudgetDetailedScreen(
     subCategoryUid: String,
     navigationActions: NavigationActions,
-    budgetAPI: BudgetAPI,
-    budgetDetailedViewModel: BudgetDetailedViewModel =
-        BudgetDetailedViewModel(budgetAPI, subCategoryUid)
+    budgetDetailedViewModel: BudgetDetailedViewModel
 ) {
   AccountingDetailedScreen(
       AccountingPage.BUDGET, subCategoryUid, navigationActions, budgetDetailedViewModel)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptGraph.kt
@@ -6,10 +6,12 @@ import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 
 fun NavGraphBuilder.receiptGraph(navigationActions: NavigationActions) {
-  composable(route = Destination.NewReceipt.route) { ReceiptScreen(navigationActions) }
+  composable(route = Destination.NewReceipt.route) {
+    ReceiptScreen(ReceiptViewModel(navigationActions))
+  }
   composable(Destination.EditReceipt("{receiptUid}").route) { backStackEntry ->
     backStackEntry.arguments?.getString("receiptUid")?.let {
-      ReceiptScreen(navActions = navigationActions, receiptUid = it)
+      ReceiptScreen(ReceiptViewModel(receiptUid = it, navActions = navigationActions))
     }
   }
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptScreen.kt
@@ -54,22 +54,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import coil.compose.AsyncImage
 import com.github.se.assocify.model.entities.Status
-import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.composables.DatePickerWithDialog
 import com.github.se.assocify.ui.composables.PhotoSelectionSheet
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ReceiptScreen(
-    navActions: NavigationActions,
-    receiptUid: String = "",
-    viewModel: ReceiptViewModel =
-        if (receiptUid.isEmpty()) {
-          ReceiptViewModel(navActions)
-        } else {
-          ReceiptViewModel(receiptUid = receiptUid, navActions = navActions)
-        }
-) {
+fun ReceiptScreen(viewModel: ReceiptViewModel) {
 
   val receiptState by viewModel.uiState.collectAsState()
 
@@ -82,7 +72,7 @@ fun ReceiptScreen(
             },
             navigationIcon = {
               IconButton(
-                  modifier = Modifier.testTag("backButton"), onClick = { navActions.back() }) {
+                  modifier = Modifier.testTag("backButton"), onClick = { viewModel.back() }) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                   }
             })

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptViewModel.kt
@@ -11,14 +11,14 @@ import com.github.se.assocify.model.entities.Status
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.util.DateUtil
 import com.github.se.assocify.ui.util.PriceUtil
-import java.time.LocalDate
-import java.util.UUID
-import kotlin.math.absoluteValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.math.absoluteValue
 
 class ReceiptViewModel {
 
@@ -218,6 +218,10 @@ class ReceiptViewModel {
           })
     }
   }
+
+    fun back() {
+        navActions.back()
+    }
 }
 
 data class ReceiptState(

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptViewModel.kt
@@ -11,14 +11,14 @@ import com.github.se.assocify.model.entities.Status
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.util.DateUtil
 import com.github.se.assocify.ui.util.PriceUtil
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.math.absoluteValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import java.time.LocalDate
-import java.util.UUID
-import kotlin.math.absoluteValue
 
 class ReceiptViewModel {
 
@@ -219,9 +219,9 @@ class ReceiptViewModel {
     }
   }
 
-    fun back() {
-        navActions.back()
-    }
+  fun back() {
+    navActions.back()
+  }
 }
 
 data class ReceiptState(


### PR DESCRIPTION
When refreshing, some pages were sending a new request to the database each time because the viewmodel was entirely recomposed. To avoid this, I'm creating the viewmodels outside of the screen and passing it as argument, everywhere where this wasn't already the case