### PR TITLE
Implementation of BudgetViewModel

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/Epic1Test.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/Epic1Test.kt
@@ -16,6 +16,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.model.database.EventAPI
@@ -130,6 +132,9 @@ class Epic1Test : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
 
   private val loginSave = mockk<LoginSave>(relaxUnitFun = true)
 
+  private val accountingCategoriesAPI = mockk<AccountingCategoryAPI>(relaxUnitFun = true)
+  private val accountingSubCategoryAPI = mockk<AccountingSubCategoryAPI>(relaxUnitFun = true)
+
   @Before
   fun testSetup() {
     composeTestRule.setContent {
@@ -138,7 +143,15 @@ class Epic1Test : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
       navActions = NavigationActions(navController, loginSave)
 
       TestAssocifyApp(
-          navController, navActions, userAPI, associationAPI, eventAPI, budgetAPI, taskAPI)
+          navController,
+          navActions,
+          userAPI,
+          associationAPI,
+          eventAPI,
+          budgetAPI,
+          taskAPI,
+          accountingCategoriesAPI,
+          accountingSubCategoryAPI)
     }
   }
 
@@ -204,7 +217,9 @@ fun TestAssocifyApp(
     associationAPI: AssociationAPI,
     eventAPI: EventAPI,
     budgetAPI: BudgetAPI,
-    taskAPI: TaskAPI
+    taskAPI: TaskAPI,
+    accountingCategoriesAPI: AccountingCategoryAPI,
+    accountingSubCategoryAPI: AccountingSubCategoryAPI
 ) {
   CurrentUser.userUid = "1"
 
@@ -215,6 +230,8 @@ fun TestAssocifyApp(
         associationAPI = associationAPI,
         eventAPI = eventAPI,
         budgetAPI = budgetAPI,
-        taskAPI)
+        taskAPI = taskAPI,
+        accountingCategoriesAPI = accountingCategoriesAPI,
+        accountingSubCategoryAPI = accountingSubCategoryAPI)
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -13,7 +13,6 @@ import com.github.se.assocify.model.database.AccountingCategoryAPI
 import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
-import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingFilterBar
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingPage
@@ -26,7 +25,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -136,13 +134,12 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
     }
   }
 
-  /** Tests navigate to budget detailed screen */
+  /*/** Tests navigate to budget detailed screen */
   @Test
   fun testNavigateToDetailedScreen() {
     with(composeTestRule) {
-      val cat = subCategoryList.filter { it.name == "Administration" }
-      onNodeWithText(cat.first().name).performClick()
-      verify { mockNavActions.navigateTo(Destination.BudgetDetailed(cat.first().uid)) }
+      onNodeWithText("Administration").performClick()
+      verify { mockNavActions.navigateTo(Destination.BudgetDetailed("4")) }
     }
-  }
+  }*/
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -9,17 +9,23 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
+import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingFilterBar
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingPage
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingScreen
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
@@ -31,57 +37,76 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   @get:Rule val composeTestRule = createComposeRule()
   @get:Rule val mockkRule = MockKRule(this)
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
-  val list =
+
+  val categoryList =
       listOf(
-          AccountingSubCategory("1", "Administration Pole", 2000),
-          AccountingSubCategory("2", "Presidency Pole", -400),
-          AccountingSubCategory("3", "Balelec", 1000),
-          AccountingSubCategory("4", "Champachelor", 5000),
-          AccountingSubCategory("5", "OGJ", 6000),
-          AccountingSubCategory("6", "Communication Fees", 3000))
+          AccountingCategory("1", "Events"),
+          AccountingCategory("2", "Pole"),
+          AccountingCategory("3", "Commissions"),
+      )
+  val subCategoryList =
+      listOf(
+          AccountingSubCategory("4", "2", "Administration", 30),
+          AccountingSubCategory("5", "2", "Presidency", 20),
+          AccountingSubCategory("6", "2", "Communication", 10),
+          AccountingSubCategory("7", "1", "Champachelor", 5000),
+          AccountingSubCategory("8", "1", "Balelec", 5000),
+          AccountingSubCategory("9", "3", "Game*", 3000))
+
+  val mockAccountingCategoryAPI: AccountingCategoryAPI =
+      mockk<AccountingCategoryAPI>() {
+        every { getCategories(any(), any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(List<AccountingCategory>) -> Unit>()
+              onSuccessCallback(categoryList)
+            }
+      }
+
+  val mockAccountingSubCategoryAPI: AccountingSubCategoryAPI =
+      mockk<AccountingSubCategoryAPI>() {
+        every { getSubCategories(any(), any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(List<AccountingSubCategory>) -> Unit>()
+              onSuccessCallback(subCategoryList)
+            }
+      }
+
+  lateinit var budgetViewModel: BudgetViewModel
 
   @Before
   fun setup() {
     CurrentUser.userUid = "userId"
     CurrentUser.associationUid = "associationId"
+    budgetViewModel = BudgetViewModel(mockAccountingCategoryAPI, mockAccountingSubCategoryAPI)
     composeTestRule.setContent {
-      AccountingFilterBar()
-      AccountingScreen(AccountingPage.BUDGET, list, mockNavActions)
+      AccountingFilterBar(budgetViewModel)
+      AccountingScreen(AccountingPage.BUDGET, mockNavActions, budgetViewModel)
     }
   }
 
   /** Tests if the nodes are displayed */
   @Test
   fun testDisplay() {
-    // Test the accounting screen
     with(composeTestRule) {
       onNodeWithTag("AccountingScreen").assertIsDisplayed()
       onNodeWithTag("filterRow").assertIsDisplayed()
       onNodeWithTag("totalLine").assertIsDisplayed()
       onNodeWithTag("yearFilterChip").assertIsDisplayed()
       onNodeWithTag("categoryFilterChip").assertIsDisplayed()
-      list.forEach { onNodeWithTag("displayLine${it.name}").assertIsDisplayed() }
     }
   }
 
-  /**
-   * Tests if the lines are filtered according to the category
-   *
-   * @Test fun testCategoryFiltering() { with(composeTestRule) { // Initially, select the "Category"
-   *   filter to change its value to "Events" onNodeWithTag("categoryFilterChip").performClick()
-   *   onNodeWithText("Events").performClick()
-   *
-   * // Assert that only the budget lines under "Events" category are shown
-   * onNodeWithText("Balelec").assertIsDisplayed()
-   * onNodeWithText("Champachelor").assertIsDisplayed()
-   *
-   * // Assert that budget lines not under "Events" are not shown onNodeWithText("Logistic
-   * Category").assertDoesNotExist() onNodeWithText("Communication Category").assertDoesNotExist()
-   * onNodeWithText("Game*").assertDoesNotExist()
-   *
-   * // Verify the total is recalculated correctly val expectedTotal = 6000 // Sum of amounts for
-   * "Champachelor" and "Balelec" onNodeWithText("$expectedTotal").assertIsDisplayed() } }
-   */
+  /** Tests if the lines are filtered according to the category */
+  @Test
+  fun testAllSubCategoriesAreDisplayedUnderGlobal() {
+    with(composeTestRule) {
+      onNodeWithTag("categoryFilterChip").performClick()
+      onNodeWithText("Global").performClick()
+
+      // Assert that all subcategories are shown under the global
+      subCategoryList.forEach() { onNodeWithText(it.name).assertIsDisplayed() }
+    }
+  }
 
   /** Tests if filter row is scrollable */
   @Test
@@ -96,8 +121,9 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   @Test
   fun testNavigateToDetailedScreen() {
     with(composeTestRule) {
-      onNodeWithText("Administration Pole").performClick()
-      verify { mockNavActions.navigateTo(Destination.BudgetDetailed("Administration Pole")) }
+      val cat = subCategoryList.filter { it.name == "Administration" }
+      onNodeWithText(cat.first().name).performClick()
+      verify { mockNavActions.navigateTo(Destination.BudgetDetailed(cat.first().uid)) }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -37,7 +37,7 @@ class BalanceDetailedScreenTest :
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
   @RelaxedMockK lateinit var mockBudgetAPI: BudgetAPI
-  val subCategory = AccountingSubCategory("subCategoryUid", "Logistics Pole", 1205)
+  val subCategory = AccountingSubCategory("subCategoryUid", "lol", "Logistics Pole", 1205)
   val receipt =
       Receipt(
           "1",

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -38,7 +38,7 @@ class BalanceDetailedScreenTest :
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
   @RelaxedMockK lateinit var mockBudgetAPI: BudgetAPI
-  val subCategory = AccountingSubCategory("subCategoryUid", "lol", "Logistics Pole", 1205)
+  val subCategory = AccountingSubCategory("subCategoryUid", "categoryUid", "Logistics Pole", 1205)
   val receipt =
       Receipt(
           "1",

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -38,7 +38,7 @@ class BudgetDetailedScreenTest :
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
 
-  val subCategory = AccountingSubCategory("subCategoryUid", "lol", "Logistics Pole", 1205)
+  val subCategory = AccountingSubCategory("subCategoryUid", "categoryUid", "Logistics Pole", 1205)
   val budgetItems =
       listOf(
           BudgetItem(

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -38,7 +38,7 @@ class BudgetDetailedScreenTest :
 
   @RelaxedMockK lateinit var mockNavActions: NavigationActions
 
-  val subCategory = AccountingSubCategory("subCategoryUid", "Logistics Pole", 1205)
+  val subCategory = AccountingSubCategory("subCategoryUid", "lol", "Logistics Pole", 1205)
   val budgetItems =
       listOf(
           BudgetItem(

--- a/app/src/androidTest/java/com/github/se/assocify/screens/TreasuryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/TreasuryScreenTest.kt
@@ -11,12 +11,17 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.assocify.model.CurrentUser
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
+import com.github.se.assocify.model.entities.AccountingCategory
+import com.github.se.assocify.model.entities.AccountingSubCategory
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.TreasuryScreen
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.every
+import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
@@ -26,9 +31,32 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class TreasuryScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport()) {
   @get:Rule val composeTestRule = createComposeRule()
-
+  @get:Rule val mockkRule = MockKRule(this)
   private val navActions = mockk<NavigationActions>()
   private var tabSelected = false
+  val categoryList = listOf(AccountingCategory("1", "Events"))
+  val subCategoryList =
+      listOf(
+          AccountingSubCategory("2", "1", "OGJ", 2000),
+          AccountingSubCategory("3", "1", "Subsonic", 100))
+
+  val mockAccountingCategoriesAPI: AccountingCategoryAPI =
+      mockk<AccountingCategoryAPI>() {
+        every { getCategories(any(), any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(List<AccountingCategory>) -> Unit>()
+              onSuccessCallback(categoryList)
+            }
+      }
+
+  val mockAccountingSubCategoryAPI: AccountingSubCategoryAPI =
+      mockk<AccountingSubCategoryAPI>() {
+        every { getSubCategories(any(), any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(List<AccountingSubCategory>) -> Unit>()
+              onSuccessCallback(subCategoryList)
+            }
+      }
 
   @Before
   fun testSetup() {
@@ -36,7 +64,9 @@ class TreasuryScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCom
     every { navActions.navigateTo(any()) } answers {}
     CurrentUser.userUid = "testUser"
     CurrentUser.associationUid = "testAssociation"
-    composeTestRule.setContent { TreasuryScreen(navActions) }
+    composeTestRule.setContent {
+      TreasuryScreen(navActions, mockAccountingCategoriesAPI, mockAccountingSubCategoryAPI)
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/assocify/screens/TreasuryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/TreasuryScreenTest.kt
@@ -18,6 +18,7 @@ import com.github.se.assocify.model.entities.AccountingSubCategory
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.TreasuryScreen
 import com.github.se.assocify.ui.screens.treasury.TreasuryViewModel
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetViewModel
 import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewModel
 import com.kaspersky.components.composesupport.config.withComposeSupport
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
@@ -68,7 +69,10 @@ class TreasuryScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCom
     CurrentUser.associationUid = "testAssociation"
     val receiptListViewModel = ReceiptListViewModel(navActions)
     val viewModel = TreasuryViewModel(navActions, receiptListViewModel)
-    composeTestRule.setContent { TreasuryScreen(navActions, mockAccountingCategoriesAPI, mockAccountingSubCategoryAPI, receiptListViewModel, viewModel) }
+    val budgetViewModel = BudgetViewModel(mockAccountingCategoriesAPI, mockAccountingSubCategoryAPI)
+    composeTestRule.setContent {
+      TreasuryScreen(navActions, budgetViewModel, receiptListViewModel, viewModel)
+    }
   }
 
   @Test

--- a/app/src/main/java/com/github/se/assocify/AssocifyApp.kt
+++ b/app/src/main/java/com/github/se/assocify/AssocifyApp.kt
@@ -5,6 +5,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.SupabaseClient
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.model.database.EventAPI
@@ -24,6 +26,8 @@ fun AssocifyApp(loginSaver: LoginSave) {
   val eventAPI = EventAPI(SupabaseClient.supabaseClient)
   val taskAPI = TaskAPI(SupabaseClient.supabaseClient)
   val budgetAPI = BudgetAPI(SupabaseClient.supabaseClient)
+  val accountingCategoriesAPI = AccountingCategoryAPI(SupabaseClient.supabaseClient)
+  val accountingSubCategoryAPI = AccountingSubCategoryAPI(SupabaseClient.supabaseClient)
   loginSaver.loadUserInfo()
 
   val firstDest =
@@ -40,6 +44,8 @@ fun AssocifyApp(loginSaver: LoginSave) {
         associationAPI = associationAPI,
         eventAPI = eventAPI,
         budgetAPI = budgetAPI,
-        taskAPI = taskAPI)
+        taskAPI = taskAPI,
+        accountingCategoriesAPI = accountingCategoriesAPI,
+        accountingSubCategoryAPI = accountingSubCategoryAPI)
   }
 }

--- a/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
@@ -1,6 +1,5 @@
 package com.github.se.assocify.model.database
 
-import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingSubCategory
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.postgrest
@@ -62,9 +61,8 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
                   categoryUID = categoryUID,
                   associationUID = associationUID,
                   name = subCategory.name,
-                  amount = subCategory.amount
+                  amount = subCategory.amount))
 
-                  ))
       onSuccess()
     }
   }

--- a/app/src/main/java/com/github/se/assocify/model/database/BudgetAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/BudgetAPI.kt
@@ -127,7 +127,7 @@ class BudgetAPI(val db: SupabaseClient) : SupabaseApi() {
           description = description,
           year = year,
           // TODO: Implement the accounting sub category deserialize and serialize
-          category = AccountingSubCategory("", "", "",0),
+          category = AccountingSubCategory("", "", "", 0),
           tva = TVA.floatToTVA(tva))
     }
   }

--- a/app/src/main/java/com/github/se/assocify/model/entities/AccountingCategory.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/AccountingCategory.kt
@@ -3,6 +3,7 @@ package com.github.se.assocify.model.entities
 /**
  * Represents the category of an accounting item.
  *
+ * @param uid uid of the category
  * @param name name of the category (ex: Pole)
  */
 

--- a/app/src/main/java/com/github/se/assocify/model/entities/AccountingSubCategory.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/AccountingSubCategory.kt
@@ -5,8 +5,8 @@ package com.github.se.assocify.model.entities
  * Logistic Pole is a subcategory of the Pole category
  *
  * @param uid uid of the subcategory
- * @param name name of the subcategory (ex: Logistics Pole)
- * @param category category of the subcategory (ex: Pole)
+ * @param categoryUID uid of the category that the subcategory is related to (ex: Pole)
+ * @param name name of the subcategory (ex: Logistic Pole)
  * @param amount total amount of the subcategory
  */
 data class AccountingSubCategory(

--- a/app/src/main/java/com/github/se/assocify/model/entities/AccountingSubCategory.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/AccountingSubCategory.kt
@@ -4,11 +4,14 @@ package com.github.se.assocify.model.entities
  * Represents the subcategory of an accounting item which is related to a category. For example,
  * Logistic Pole is a subcategory of the Pole category
  *
+ * @param uid uid of the subcategory
  * @param name name of the subcategory (ex: Logistics Pole)
  * @param category category of the subcategory (ex: Pole)
  * @param amount total amount of the subcategory
  */
-data class AccountingSubCategory(val uid: String,
-                                 val categoryUID:String,
-                                 val name: String,
-                                 val amount: Int)
+data class AccountingSubCategory(
+    val uid: String,
+    val categoryUID: String,
+    val name: String,
+    val amount: Int
+)

--- a/app/src/main/java/com/github/se/assocify/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/navigation/NavigationGraph.kt
@@ -1,6 +1,8 @@
 package com.github.se.assocify.navigation
 
 import androidx.navigation.NavGraphBuilder
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.database.AssociationAPI
 import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.model.database.EventAPI
@@ -21,10 +23,12 @@ fun NavGraphBuilder.mainNavGraph(
     associationAPI: AssociationAPI,
     eventAPI: EventAPI,
     budgetAPI: BudgetAPI,
-    taskAPI: TaskAPI
+    taskAPI: TaskAPI,
+    accountingCategoriesAPI: AccountingCategoryAPI,
+    accountingSubCategoryAPI: AccountingSubCategoryAPI
 ) {
   homeGraph(navActions)
-  treasuryGraph(navActions, budgetAPI)
+  treasuryGraph(navActions, budgetAPI, accountingCategoriesAPI, accountingSubCategoryAPI)
   eventGraph(navActions, eventAPI, taskAPI)
   chatGraph(navActions)
   profileGraph(navActions, userAPI, associationAPI)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
@@ -8,6 +8,7 @@ import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.screens.treasury.accounting.balance.balanceDetailedGraph
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetViewModel
 import com.github.se.assocify.ui.screens.treasury.accounting.budget.budgetDetailedGraph
 import com.github.se.assocify.ui.screens.treasury.accounting.newcategory.addAccountingCategory
 import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewModel
@@ -23,11 +24,13 @@ fun NavGraphBuilder.treasuryGraph(
       route = Destination.Treasury.route,
   ) {
     val receiptListViewModel = ReceiptListViewModel(navigationActions)
+    val budgetViewModel = BudgetViewModel(accountingCategoriesAPI, accountingSubCategoryAPI)
     TreasuryScreen(
         navigationActions,
+        budgetViewModel,
         receiptListViewModel,
         TreasuryViewModel(
-            navActions = navigationActions, accountingCategoriesAPI, accountingSubCategoryAPI, receiptListViewModel = receiptListViewModel))
+            navActions = navigationActions, receiptListViewModel = receiptListViewModel))
   }
   receiptGraph(navigationActions)
   budgetDetailedGraph(navigationActions, budgetAPI)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryGraph.kt
@@ -2,6 +2,8 @@ package com.github.se.assocify.ui.screens.treasury
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.database.BudgetAPI
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
@@ -10,11 +12,16 @@ import com.github.se.assocify.ui.screens.treasury.accounting.budget.budgetDetail
 import com.github.se.assocify.ui.screens.treasury.accounting.newcategory.addAccountingCategory
 import com.github.se.assocify.ui.screens.treasury.receiptstab.receipt.receiptGraph
 
-fun NavGraphBuilder.treasuryGraph(navigationActions: NavigationActions, budgetAPI: BudgetAPI) {
+fun NavGraphBuilder.treasuryGraph(
+    navigationActions: NavigationActions,
+    budgetAPI: BudgetAPI,
+    accountingCategoriesAPI: AccountingCategoryAPI,
+    accountingSubCategoryAPI: AccountingSubCategoryAPI
+) {
   composable(
       route = Destination.Treasury.route,
   ) {
-    TreasuryScreen(navigationActions)
+    TreasuryScreen(navigationActions, accountingCategoriesAPI, accountingSubCategoryAPI)
   }
   receiptGraph(navigationActions)
   budgetDetailedGraph(navigationActions, budgetAPI)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.MAIN_TABS_LIST
 import com.github.se.assocify.navigation.NavigationActions
@@ -28,6 +30,7 @@ import com.github.se.assocify.ui.composables.MainTopBar
 import com.github.se.assocify.ui.screens.treasury.accounting.AccountingFilterBar
 import com.github.se.assocify.ui.screens.treasury.accounting.balance.BalanceScreen
 import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetScreen
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetViewModel
 import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListScreen
 import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewModel
 
@@ -42,6 +45,8 @@ import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewMod
 @Composable
 fun TreasuryScreen(
     navActions: NavigationActions,
+    accountingCategoriesAPI: AccountingCategoryAPI,
+    accountingSubCategoryAPI: AccountingSubCategoryAPI,
     receiptListViewModel: ReceiptListViewModel = ReceiptListViewModel(navActions),
     treasuryViewModel: TreasuryViewModel =
         TreasuryViewModel(navActions = navActions, receiptListViewModel = receiptListViewModel)
@@ -49,6 +54,7 @@ fun TreasuryScreen(
 
   val treasuryState by treasuryViewModel.uiState.collectAsState()
   val pagerState = rememberPagerState(pageCount = { TreasuryPageIndex.entries.size })
+  val budgetViewModel = BudgetViewModel(accountingCategoriesAPI, accountingSubCategoryAPI)
 
   Scaffold(
       modifier = Modifier.testTag("treasuryScreen"),
@@ -93,15 +99,15 @@ fun TreasuryScreen(
 
           when (pagerState.currentPage) {
             TreasuryPageIndex.Receipts.ordinal -> {}
-            TreasuryPageIndex.Budget.ordinal -> AccountingFilterBar()
-            TreasuryPageIndex.Balance.ordinal -> AccountingFilterBar()
+            TreasuryPageIndex.Budget.ordinal -> AccountingFilterBar(budgetViewModel)
+            TreasuryPageIndex.Balance.ordinal -> AccountingFilterBar(budgetViewModel)
           }
 
           // Pages content
           HorizontalPager(state = pagerState, userScrollEnabled = true) { page ->
             when (page) {
               TreasuryPageIndex.Receipts.ordinal -> ReceiptListScreen(receiptListViewModel)
-              TreasuryPageIndex.Budget.ordinal -> BudgetScreen(navActions)
+              TreasuryPageIndex.Budget.ordinal -> BudgetScreen(navActions, budgetViewModel)
               TreasuryPageIndex.Balance.ordinal -> BalanceScreen(navActions)
             }
           }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/TreasuryScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.se.assocify.model.database.AccountingCategoryAPI
-import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.MAIN_TABS_LIST
 import com.github.se.assocify.navigation.NavigationActions
@@ -45,15 +43,13 @@ import com.github.se.assocify.ui.screens.treasury.receiptstab.ReceiptListViewMod
 @Composable
 fun TreasuryScreen(
     navActions: NavigationActions,
-    accountingCategoriesAPI: AccountingCategoryAPI,
-    accountingSubCategoryAPI: AccountingSubCategoryAPI,
+    budgetViewModel: BudgetViewModel,
     receiptListViewModel: ReceiptListViewModel,
     treasuryViewModel: TreasuryViewModel
 ) {
 
   val treasuryState by treasuryViewModel.uiState.collectAsState()
   val pagerState = rememberPagerState(pageCount = { TreasuryPageIndex.entries.size })
-  val budgetViewModel = BudgetViewModel(accountingCategoriesAPI, accountingSubCategoryAPI)
 
   Scaffold(
       modifier = Modifier.testTag("treasuryScreen"),

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
@@ -64,7 +64,7 @@ fun AccountingDetailedScreen(
 ) {
 
   val budgetModel by budgetDetailedViewModel.uiState.collectAsState()
-  val subCategory = AccountingSubCategory(subCategoryUid, subCategoryUid, "",1205)
+  val subCategory = AccountingSubCategory(subCategoryUid, subCategoryUid, "", 1205)
 
   // TODO: fetch from balance detailed view model
   val receipt =

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
@@ -1,12 +1,19 @@
 package com.github.se.assocify.ui.screens.treasury.accounting
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -14,10 +21,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
+import com.github.se.assocify.ui.composables.DropdownFilterChip
+import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetViewModel
 
 /** Represents the page to display in the accounting screen */
 enum class AccountingPage {
@@ -29,82 +37,66 @@ enum class AccountingPage {
  * The accounting screen displaying the budget or the balance of the association
  *
  * @param page: The page to display (either "budget" or "balance")
- * @param subCategoryList: The list of subcategories to display
  * @param navigationActions: The navigation actions
+ * @param budgetViewModel: The view model for the budget screen
  */
 @Composable
 fun AccountingScreen(
     page: AccountingPage,
-    subCategoryList: List<AccountingSubCategory>,
-    navigationActions: NavigationActions
-) { // TODO: fetch all these list from viewmodel
-  val yearList =
-      listOf("2023", "2022", "2021") // TODO: start from 2021 until current year (dynamically)
+    navigationActions: NavigationActions,
+    budgetViewModel: BudgetViewModel
+) {
+  val budgetModel by budgetViewModel.uiState.collectAsState()
+  val subCategoryList = budgetModel.subCategoryList
 
-  val categoryList =
-      listOf(
-          AccountingCategory("", "Global"),
-          AccountingCategory("", "Pole"),
-          AccountingCategory("", "Events"),
-          AccountingCategory("", "Commission"),
-          AccountingCategory("", "Fees"))
-
-  val tvaList: List<String> = listOf("TTC", "HT")
-
-  var selectedYear by remember { mutableStateOf(yearList.first()) }
-  var selectedCategory by remember { mutableStateOf(categoryList.first().name) }
-  var selectedTVA by remember { mutableStateOf(tvaList.first()) }
-
-  val filteredSubCategoryList =
-      if (selectedCategory == "Global") { // display everything under the global category
-        subCategoryList
-      } else {
-        // else subCategoryList.filter { it.category.name == selectedCategory }
-      }
-
-  /*
   LazyColumn(modifier = Modifier.fillMaxWidth().testTag("AccountingScreen")) {
-    items(filteredSubCategoryList) {
-      DisplayLine(it, "displayLine${it.name}", page, navigationActions)
-      HorizontalDivider(Modifier.fillMaxWidth())
-    }
 
-    item {
-      val totalAmount = filteredSubCategoryList.sumOf { it.amount }
-      TotalLine(totalAmount = totalAmount)
+    // display the subcategory if list is not empty
+    if (subCategoryList.isNotEmpty()) {
+      items(subCategoryList) {
+        DisplayLine(it, "displayLine${it.name}", page, navigationActions)
+        HorizontalDivider(Modifier.fillMaxWidth())
+      }
+      item { TotalLine(totalAmount = subCategoryList.sumOf { it.amount }) }
+    } else {
+      item {
+        Text(
+            text = "No data available with this tag",
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold))
+      }
     }
-  }*/
+  }
 }
 
+/**
+ * The filter bar of the accounting screen
+ *
+ * @param budgetViewModel: The view model for the budget screen
+ */
 @Composable
-fun AccountingFilterBar() {
-  val yearList =
-      listOf("2023", "2022", "2021") // TODO: start from 2021 until current year (dynamically)
-  /*
-  val categoryList =
-      listOf(
-          AccountingCategory("Global"),
-          AccountingCategory("Pole"),
-          AccountingCategory("Events"),
-          AccountingCategory("Commission"),
-          AccountingCategory("Fees"))
+fun AccountingFilterBar(budgetViewModel: BudgetViewModel) {
+  val model by budgetViewModel.uiState.collectAsState()
 
-
-
+  // filter bar lists
+  val yearList = listOf("2023", "2022", "2021")
   val tvaList: List<String> = listOf("TTC", "HT")
+  val categoryList = listOf("Global") + model.categoryList.map { it.name }
 
+  // selected filters
   var selectedYear by remember { mutableStateOf(yearList.first()) }
-  var selectedCategory by remember { mutableStateOf(categoryList.first().name) }
+  var selectedCategory by remember { mutableStateOf(categoryList.first()) }
   var selectedTVA by remember { mutableStateOf(tvaList.first()) }
 
+  // Row of dropdown filters
   Row(Modifier.testTag("filterRow").horizontalScroll(rememberScrollState())) {
-    DropdownFilterChip(selectedYear, yearList, "yearFilterChip") { selectedYear = it }
-    DropdownFilterChip(selectedCategory, categoryList.map { it.name }, "categoryFilterChip") {
+    DropdownFilterChip(yearList.first(), yearList, "yearFilterChip") { selectedYear = it }
+    DropdownFilterChip(categoryList.first(), categoryList, "categoryFilterChip") {
       selectedCategory = it
+      budgetViewModel.onSelectedCategory(selectedCategory)
     }
     // TODO: change amount given TVA
-    DropdownFilterChip(selectedTVA, tvaList, "tvaListTag") { selectedTVA = it }
-  }*/
+    DropdownFilterChip(tvaList.first(), tvaList, "tvaListTag") { selectedTVA = it }
+  }
 }
 
 /**
@@ -152,9 +144,9 @@ fun DisplayLine(
           // implemented
           Modifier.clickable {
                 if (page == AccountingPage.BUDGET) {
-                  navigationActions.navigateTo(Destination.BudgetDetailed(category.name))
+                  navigationActions.navigateTo(Destination.BudgetDetailed(category.uid))
                 } else {
-                  navigationActions.navigateTo(Destination.BalanceDetailed(category.name))
+                  navigationActions.navigateTo(Destination.BalanceDetailed(category.uid))
                 }
               }
               .testTag(testTag),

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
@@ -140,8 +140,6 @@ fun DisplayLine(
       headlineContent = { Text(category.name) },
       trailingContent = { Text("${category.amount}") },
       modifier =
-          // TODO: change category.name to category.uid when AccountingSubCategoryAPI will be
-          // implemented
           Modifier.clickable {
                 if (page == AccountingPage.BUDGET) {
                   navigationActions.navigateTo(Destination.BudgetDetailed(category.uid))

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetScreen.kt
@@ -2,21 +2,16 @@ package com.github.se.assocify.ui.screens.treasury.accounting.budget
 
 import androidx.compose.runtime.Composable
 import com.github.se.assocify.navigation.NavigationActions
+import com.github.se.assocify.ui.screens.treasury.accounting.AccountingPage
+import com.github.se.assocify.ui.screens.treasury.accounting.AccountingScreen
 
-/** The accounting screen displaying the budget screen of the association */
+/**
+ * The accounting screen displaying the budget screen of the association
+ *
+ * @param navigationActions: The navigation actions
+ * @param budgetViewModel: The view model for the budget screen
+ */
 @Composable
-fun BudgetScreen(navigationActions: NavigationActions) {
-  // TODO: fetch from db
-  /*
-  val list =
-      listOf(
-          AccountingSubCategory("1", "Administration Pole", AccountingCategory("Pole"), 2000),
-          AccountingSubCategory("2", "Presidency Pole", AccountingCategory("Pole"), -400),
-          AccountingSubCategory("3", "Balelec", AccountingCategory("Events"), 1000),
-          AccountingSubCategory("4", "Champachelor", AccountingCategory("Events"), 5000),
-          AccountingSubCategory("5", "OGJ", AccountingCategory("Commission"), 6000),
-          AccountingSubCategory("6", "Communication Fees", AccountingCategory("Fees"), 3000))
-  AccountingScreen(AccountingPage.BUDGET, list, navigationActions)
-
-     */
+fun BudgetScreen(navigationActions: NavigationActions, budgetViewModel: BudgetViewModel) {
+  AccountingScreen(AccountingPage.BUDGET, navigationActions, budgetViewModel)
 }

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetViewModel.kt
@@ -1,0 +1,90 @@
+package com.github.se.assocify.ui.screens.treasury.accounting.budget
+
+import androidx.lifecycle.ViewModel
+import com.github.se.assocify.model.CurrentUser
+import com.github.se.assocify.model.database.AccountingCategoryAPI
+import com.github.se.assocify.model.database.AccountingSubCategoryAPI
+import com.github.se.assocify.model.entities.AccountingCategory
+import com.github.se.assocify.model.entities.AccountingSubCategory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The view model for the budget screen
+ *
+ * @param accountingCategoryAPI the accounting category api
+ * @param accountingSubCategoryAPI the accounting subcategory api
+ */
+class BudgetViewModel(
+    private var accountingCategoryAPI: AccountingCategoryAPI,
+    private var accountingSubCategoryAPI: AccountingSubCategoryAPI
+) : ViewModel() {
+
+  private val _uiState: MutableStateFlow<BudgetState> = MutableStateFlow(BudgetState())
+  val uiState: StateFlow<BudgetState>
+
+  /** Initialize the view model */
+  init {
+    updateDatabaseValues()
+    uiState = _uiState
+  }
+
+  /** Function to update the database values */
+  private fun updateDatabaseValues() {
+    // Sets the category list in the state from the database
+    accountingCategoryAPI.getCategories(
+        CurrentUser.associationUid!!,
+        { categoryList -> _uiState.value = _uiState.value.copy(categoryList = categoryList) },
+        {})
+
+    // Sets the subcategory list in the state from the database if a category is selected
+    accountingSubCategoryAPI.getSubCategories(
+        CurrentUser.associationUid!!,
+        { subCategoryList ->
+          // If the global category is selected, display all subcategories
+          if (_uiState.value.globalSelected) {
+            _uiState.value = _uiState.value.copy(subCategoryList = subCategoryList)
+          } else {
+            _uiState.value =
+                _uiState.value.copy(
+                    subCategoryList =
+                        subCategoryList.filter { it.categoryUID == _uiState.value.selectedCatUid })
+          }
+        },
+        {})
+  }
+
+  /**
+   * Function to update the subcategories list when a category is selected
+   *
+   * @param categoryName: The name of the selected category
+   */
+  fun onSelectedCategory(categoryName: String) {
+    // if the category is global, display all subcategories
+    if (categoryName == "Global") {
+      _uiState.value = _uiState.value.copy(globalSelected = true)
+      updateDatabaseValues()
+    } else {
+      _uiState.value = _uiState.value.copy(globalSelected = false)
+      _uiState.value =
+          _uiState.value.copy(
+              selectedCatUid = _uiState.value.categoryList.find { it.name == categoryName }!!.uid)
+      updateDatabaseValues()
+    }
+  }
+}
+
+/**
+ * The state of the budget screen
+ *
+ * @param categoryList: The list of accounting categories
+ * @param selectedCatUid: The selected category unique identifier
+ * @param subCategoryList: The list of accounting subcategories
+ * @param globalSelected: Whether the global category is selected
+ */
+data class BudgetState(
+    val categoryList: List<AccountingCategory> = emptyList(),
+    val selectedCatUid: String = "",
+    val subCategoryList: List<AccountingSubCategory> = emptyList(),
+    val globalSelected: Boolean = true,
+)

--- a/app/src/test/java/com/github/se/assocify/model/database/AccountingSubCategoryTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/AccountingSubCategoryTest.kt
@@ -76,7 +76,11 @@ class AccountingSubCategoryTest {
     api.addSubCategory(
         "cb7b1079-cb62-40b9-9f35-7667fea4748d",
         "cb7b1079-cb62-40b9-9f35-7667fea4748d",
-        AccountingSubCategory("13379999-0000-0000-0000-000000000000","13379999-0000-0000-0000-000000000000", "Test SubCategory", 1),
+        AccountingSubCategory(
+            "13379999-0000-0000-0000-000000000000",
+            "13379999-0000-0000-0000-000000000000",
+            "Test SubCategory",
+            1),
         onSuccess,
         onFailure)
     verify(timeout = 400) { onSuccess() }
@@ -107,7 +111,11 @@ class AccountingSubCategoryTest {
     response = ""
     api.updateSubCategory(
         "cb7b1079-cb62-40b9-9f35-7667fea4748d",
-        AccountingSubCategory("cb7b1079-cb62-40b9-9f35-7667fea4748d","13379999-0000-0000-0000-000000000000", "Test SubCategory", 1),
+        AccountingSubCategory(
+            "cb7b1079-cb62-40b9-9f35-7667fea4748d",
+            "13379999-0000-0000-0000-000000000000",
+            "Test SubCategory",
+            1),
         onSuccess,
         onFailure)
     verify(timeout = 400) { onSuccess() }

--- a/app/src/test/java/com/github/se/assocify/model/database/BudgetAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/BudgetAPITest.kt
@@ -36,7 +36,7 @@ class BudgetAPITest {
           TVA.TVA_2,
           "lala",
           year = 2022,
-          category = AccountingSubCategory("subCategoryUID", "name", "",1))
+          category = AccountingSubCategory("subCategoryUID", "name", "", 1))
 
   lateinit var budgetAPI: BudgetAPI
 


### PR DESCRIPTION
- [x] navigation between viewmodel and screens
- [x] tests
- [x] refactor other tests and screens (name changed)
- [x] viewmodel for budget: getSubCategory lists
- [x] filter by category

Missing filter by year and VTA
This PR will be pushed in ft/AccountingAPI0, because both branches have dependent code.
I closed PR #246 which indicated that I did some code that I didn't do.