### PR TITLE
Fix time problems on the treasury page

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/AccountingScreenTest.kt
@@ -1,6 +1,7 @@
 package com.github.se.assocify.screens
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -25,6 +26,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
+import java.lang.Thread.sleep
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -45,12 +47,12 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
 
   val subCategoryList =
       listOf(
-          AccountingSubCategory("4", "2", "Administration", 30, 10),
-          AccountingSubCategory("5", "2", "Presidency", 20, 10),
-          AccountingSubCategory("6", "2", "Communication", 10, 10),
-          AccountingSubCategory("7", "1", "Champachelor", 5000, 1000),
-          AccountingSubCategory("8", "1", "Balelec", 5000, 1000),
-          AccountingSubCategory("9", "3", "Game*", 3000, 1000),
+          AccountingSubCategory("4", "2", "Administration", 30, 2023),
+          AccountingSubCategory("5", "2", "Presidency", 20, 2023),
+          AccountingSubCategory("6", "2", "Communication", 10, 2023),
+          AccountingSubCategory("7", "1", "Champachelor", 5000, 2022),
+          AccountingSubCategory("8", "1", "Balelec", 5000, 2022),
+          AccountingSubCategory("9", "3", "Game*", 3000, 2022),
       )
 
   val mockAccountingCategoryAPI: AccountingCategoryAPI =
@@ -91,7 +93,7 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
     with(composeTestRule) {
       onNodeWithTag("AccountingScreen").assertIsDisplayed()
       onNodeWithTag("filterRow").assertIsDisplayed()
-      onNodeWithTag("totalLine").assertIsDisplayed()
+      onNodeWithTag("totalLine").assertIsNotDisplayed()
       onNodeWithTag("yearFilterChip").assertIsDisplayed()
       onNodeWithTag("categoryFilterChip").assertIsDisplayed()
     }
@@ -101,12 +103,16 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
   @Test
   fun testFiltering() {
     with(composeTestRule) {
+      onNodeWithTag("yearFilterChip").performClick()
+      sleep(2000)
+      onNodeWithText("2022").performClick()
       onNodeWithTag("categoryFilterChip").performClick()
 
       // Tests if the lines are filtered according to the category
       onNodeWithText("Events").performClick()
       subCategoryList
           .filter { it.categoryUID == "1" }
+          .filter { it.year == 2022 }
           .forEach() { onNodeWithText(it.name).assertIsDisplayed() }
       assert(!accountingViewModel.uiState.value.globalSelected)
       assert(
@@ -116,9 +122,13 @@ class AccountingScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withC
       // Tests if the lines are displayed when the global category is selected
       onNodeWithTag("categoryFilterChip").performClick()
       onNodeWithText("Global").performClick()
-      subCategoryList.forEach() { onNodeWithText(it.name).assertIsDisplayed() }
+      subCategoryList
+          .filter { it.year == 2022 }
+          .forEach() { onNodeWithText(it.name).assertIsDisplayed() }
       assert(accountingViewModel.uiState.value.globalSelected)
-      assert(accountingViewModel.uiState.value.subCategoryList == subCategoryList)
+      assert(
+          accountingViewModel.uiState.value.subCategoryList ==
+              subCategoryList.filter { it.year == 2022 })
 
       // Tests if a message is shown when no subCategory
       onNodeWithTag("categoryFilterChip").performClick()

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -139,7 +139,7 @@ class BalanceDetailedScreenTest :
   fun testEmptyList() {
     with(composeTestRule) {
       onNodeWithTag("yearListTag").performClick()
-      onNodeWithText("2021").performClick()
+      onNodeWithText("2024").performClick()
       onNodeWithTag("totalItems").assertIsNotDisplayed()
       onNodeWithText("No items for the ${subCategoryList.first().name} sheet with these filters")
           .assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -130,7 +130,7 @@ class BudgetDetailedScreenTest :
   fun testEmptyList() {
     with(composeTestRule) {
       onNodeWithTag("yearListTag").performClick()
-      onNodeWithText("2021").performClick()
+      onNodeWithText("2024").performClick()
       onNodeWithTag("totalItems").assertIsNotDisplayed()
       onNodeWithText("No items for the ${subCategoryList.first().name} sheet with these filters")
           .assertIsDisplayed()

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
@@ -60,6 +60,7 @@ import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.composables.DropdownFilterChip
 import com.github.se.assocify.ui.screens.treasury.accounting.balance.BalanceDetailedViewModel
 import com.github.se.assocify.ui.screens.treasury.accounting.budget.BudgetDetailedViewModel
+import com.github.se.assocify.ui.util.DateUtil
 
 /**
  * The detailed screen of a subcategory in the accounting screen
@@ -83,7 +84,7 @@ fun AccountingDetailedScreen(
   val balanceModel by balanceDetailedViewModel.uiState.collectAsState()
   val subCategory = AccountingSubCategory(subCategoryUid, subCategoryUid, "", 1205, 2023)
 
-  val yearList = listOf("2023", "2022", "2021")
+  val yearList = DateUtil.getYearList()
   val statusList: List<String> = listOf("All Status") + Status.entries.map { it.name }
   val tvaList: List<String> = listOf("TTC", "HT")
 

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
@@ -25,6 +25,7 @@ import com.github.se.assocify.model.entities.AccountingSubCategory
 import com.github.se.assocify.navigation.Destination
 import com.github.se.assocify.navigation.NavigationActions
 import com.github.se.assocify.ui.composables.DropdownFilterChip
+import com.github.se.assocify.ui.util.DateUtil
 
 /** Represents the page to display in the accounting screen */
 enum class AccountingPage {
@@ -77,7 +78,7 @@ fun AccountingFilterBar(accountingViewModel: AccountingViewModel) {
   val model by accountingViewModel.uiState.collectAsState()
 
   // filter bar lists
-  val yearList = listOf("2023", "2022", "2021")
+  val yearList = DateUtil.getYearList()
   val tvaList: List<String> = listOf("TTC", "HT")
   val categoryList = listOf("Global") + model.categoryList.map { it.name }
 

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingScreen.kt
@@ -50,7 +50,6 @@ fun AccountingScreen(
   val subCategoryList = model.subCategoryList
 
   LazyColumn(modifier = Modifier.fillMaxWidth().testTag("AccountingScreen")) {
-
     // display the subcategory if list is not empty
     if (subCategoryList.isNotEmpty()) {
       items(subCategoryList) {
@@ -89,7 +88,10 @@ fun AccountingFilterBar(accountingViewModel: AccountingViewModel) {
 
   // Row of dropdown filters
   Row(Modifier.testTag("filterRow").horizontalScroll(rememberScrollState())) {
-    DropdownFilterChip(yearList.first(), yearList, "yearFilterChip") { selectedYear = it }
+    DropdownFilterChip(yearList.first(), yearList, "yearFilterChip") {
+      selectedYear = it
+      accountingViewModel.onYearFilter(selectedYear.toInt())
+    }
     DropdownFilterChip(categoryList.first(), categoryList, "categoryFilterChip") {
       selectedCategory = it
       accountingViewModel.onSelectedCategory(selectedCategory)

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
@@ -6,9 +6,10 @@ import com.github.se.assocify.model.database.AccountingCategoryAPI
 import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
-import java.time.Year
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.time.LocalDate
+
 
 /**
  * The view model for the budget screen
@@ -100,5 +101,5 @@ data class AccountingState(
     val selectedCatUid: String = "",
     val subCategoryList: List<AccountingSubCategory> = emptyList(),
     val globalSelected: Boolean = true,
-    val yearFilter: Int = Year.now().value
+    val yearFilter: Int = LocalDate.now().year
 )

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
@@ -7,7 +7,6 @@ import com.github.se.assocify.model.database.AccountingCategoryAPI
 import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
-import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -101,5 +100,5 @@ data class AccountingState(
     val selectedCatUid: String = "",
     val subCategoryList: List<AccountingSubCategory> = emptyList(),
     val globalSelected: Boolean = true,
-    val yearFilter: Int = LocalDate.now().year
+    val yearFilter: Int = 2024
 )

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
@@ -6,6 +6,7 @@ import com.github.se.assocify.model.database.AccountingCategoryAPI
 import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
+import java.time.Year
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -99,5 +100,5 @@ data class AccountingState(
     val selectedCatUid: String = "",
     val subCategoryList: List<AccountingSubCategory> = emptyList(),
     val globalSelected: Boolean = true,
-    val yearFilter: Int = 2024
+    val yearFilter: Int = Year.now().value
 )

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
@@ -48,7 +48,10 @@ class AccountingViewModel(
             _uiState.value =
                 _uiState.value.copy(
                     subCategoryList =
-                        subCategoryList.filter { it.categoryUID == _uiState.value.selectedCatUid })
+                        subCategoryList.filter {
+                          it.categoryUID == _uiState.value.selectedCatUid &&
+                              it.year == _uiState.value.yearFilter
+                        })
           }
         },
         {})
@@ -72,6 +75,12 @@ class AccountingViewModel(
       updateDatabaseValues()
     }
   }
+
+  /** Function to update the year filter */
+  fun onYearFilter(yearFilter: Int) {
+    _uiState.value = _uiState.value.copy(yearFilter = yearFilter)
+    updateDatabaseValues()
+  }
 }
 
 /**
@@ -87,4 +96,5 @@ data class AccountingState(
     val selectedCatUid: String = "",
     val subCategoryList: List<AccountingSubCategory> = emptyList(),
     val globalSelected: Boolean = true,
+    val yearFilter: Int = 2023
 )

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
@@ -6,10 +6,9 @@ import com.github.se.assocify.model.database.AccountingCategoryAPI
 import com.github.se.assocify.model.database.AccountingSubCategoryAPI
 import com.github.se.assocify.model.entities.AccountingCategory
 import com.github.se.assocify.model.entities.AccountingSubCategory
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import java.time.LocalDate
-
 
 /**
  * The view model for the budget screen

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingViewModel.kt
@@ -43,7 +43,10 @@ class AccountingViewModel(
         { subCategoryList ->
           // If the global category is selected, display all subcategories
           if (_uiState.value.globalSelected) {
-            _uiState.value = _uiState.value.copy(subCategoryList = subCategoryList)
+            _uiState.value =
+                _uiState.value.copy(
+                    subCategoryList =
+                        subCategoryList.filter { it.year == _uiState.value.yearFilter })
           } else {
             _uiState.value =
                 _uiState.value.copy(
@@ -96,5 +99,5 @@ data class AccountingState(
     val selectedCatUid: String = "",
     val subCategoryList: List<AccountingSubCategory> = emptyList(),
     val globalSelected: Boolean = true,
-    val yearFilter: Int = 2023
+    val yearFilter: Int = 2024
 )

--- a/app/src/main/java/com/github/se/assocify/ui/util/DateUtil.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/util/DateUtil.kt
@@ -27,4 +27,8 @@ object DateUtil {
     }
     return java.time.LocalDate.parse(date, DateTimeFormatter.ofPattern("dd/MM/yyyy"))
   }
+
+  fun getYearList(): List<String> {
+    return (2021..java.time.LocalDate.now().year).map { it.toString() }
+  }
 }


### PR DESCRIPTION
The treasury page contains some problems, which are the fact that the year list is harcoded and the year filter does not work on the overview screen. The objective of this PR is to fix these two linked problems so that the utilization of time in the tresury tab becomes finally correct

- [x] Remove the hardcoded lists
- [x] Filter the year list depending on the year selected