### PR TITLE
Allow to move subcategories between categories in DB

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
@@ -82,6 +82,8 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       db.postgrest.from(collection).update({
         SupabaseAccountingSubCategory::name setTo subCategory.name
         SupabaseAccountingSubCategory::amount setTo subCategory.amount
+        SupabaseAccountingSubCategory::year setTo subCategory.year
+        SupabaseAccountingSubCategory::categoryUID setTo subCategory.categoryUID
       }) {
         filter { SupabaseAccountingSubCategory::uid eq subCategory.uid }
       }


### PR DESCRIPTION
PATCH : the last PR that wasn't functional.
Now in the DB it is possible to edit the categoryUID of a subcategory.
