### PR TITLE
Receipt caching

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
@@ -101,7 +101,7 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
       db.from("receipt_status").upsert(LinkedReceiptStatus(sreceipt.uid, receipt.status))
 
       // Update the cache
-      if (CurrentUser.userUid == userUid) {
+      if (CurrentUser.userUid != userUid) {
         // Invalidate cache if the user changed
         userReceipts = null
         receipts = null

--- a/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
@@ -193,7 +193,7 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
    * @param onFailure called whenever an error has occurred with the exception that occurred
    */
   fun getAllReceipts(onSuccess: (List<Receipt>) -> Unit, onFailure: (Exception) -> Unit) {
-    if (receipts != null) {
+    if (receipts != null && userUid == CurrentUser.userUid) {
       onSuccess(receipts!!)
       return
     }

--- a/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
@@ -39,6 +39,10 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
   /// The user's UID
   private var userUid: String? = CurrentUser.userUid
 
+  init {
+    updateCaches({ _, _ -> }, { _, _ -> })
+  }
+
   // TODO: caches should use mutable lists to be more efficient
   private fun updateReceiptInList(receipt: Receipt, receipts: List<Receipt>): List<Receipt> {
     val index = receipts.indexOfFirst { r -> r.uid == receipt.uid }

--- a/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
@@ -31,6 +31,14 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
               .trimIndent()
               .filter { it != '\n' })
 
+  /// The list of receipts owned by the user
+  private var userReceipts: List<Receipt>? = null
+  // The list of *all* receipts (if the user doesn't have permission to see all receipts, this
+  // will be the same as userReceipts)
+  private var receipts: List<Receipt>? = null
+  /// The user's UID
+  private var userUid: String? = CurrentUser.userUid
+
   /**
    * Uploads a receipt to the database, as well as the image (if needed). Can create or update a
    * receipt.
@@ -100,6 +108,48 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
     }
   }
 
+  private fun updateUserCache(onSuccess: (List<Receipt>) -> Unit, onFailure: (Exception) -> Unit) {
+    tryAsync(onFailure) {
+      userReceipts =
+          db.from("receipt")
+              .select(columns) { filter { SupabaseReceipt::userId eq CurrentUser.userUid } }
+              .decodeList<SupabaseReceipt>()
+              .map { it.toReceipt() }
+      userUid = CurrentUser.userUid
+
+      onSuccess(userReceipts!!)
+    }
+  }
+
+  private fun updateCache(onSuccess: (List<Receipt>) -> Unit, onFailure: (Exception) -> Unit) {
+    tryAsync(onFailure) {
+      receipts =
+          db.from("receipt").select(columns).decodeList<SupabaseReceipt>().map { it.toReceipt() }
+
+      onSuccess(receipts!!)
+    }
+  }
+
+  /**
+   * Updates the caches of receipts. This is useful when the user wants to refresh the list of
+   * receipts.
+   *
+   * @param onSuccess called when the update is successful with the list of receipts. The boolean
+   *   parameter indicates whether the user's receipts were updated (`true`), or the global receipts
+   *   (`false`). Thus, this lambda will be called up to 2 times.
+   * @param onFailure called when the update fails with the exception that occurred. The boolean
+   *   parameter indicates whether the user's receipts were updated (`true`), or the global receipts
+   *   (`false`). Thus, this lambda will be called up to 2 times.
+   */
+  fun updateCaches(
+      onSuccess: (Boolean, List<Receipt>) -> Unit,
+      onFailure: (Boolean, Exception) -> Unit
+  ) {
+    updateUserCache({ onSuccess(true, it) }, { onFailure(true, it) })
+
+    updateCache({ onSuccess(false, it) }, { onFailure(false, it) })
+  }
+
   /**
    * Gets all receipts created by the current user.
    *
@@ -107,13 +157,12 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
    * @param onFailure called when the fetch fails with the exception that occurred
    */
   fun getUserReceipts(onSuccess: (List<Receipt>) -> Unit, onFailure: (Exception) -> Unit) {
-    tryAsync(onFailure) {
-      onSuccess(
-          db.from("receipt")
-              .select(columns) { filter { SupabaseReceipt::userId eq CurrentUser.userUid } }
-              .decodeList<SupabaseReceipt>()
-              .map { it.toReceipt() })
+    if (userReceipts != null && userUid == CurrentUser.userUid) {
+      onSuccess(userReceipts!!)
+      return
     }
+
+    updateUserCache(onSuccess, onFailure)
   }
 
   /**
@@ -124,14 +173,17 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
    * @param onFailure called when the fetch fails with the exception that occurred
    */
   fun getReceipt(id: String, onSuccess: (Receipt) -> Unit, onFailure: (Exception) -> Unit) {
-    tryAsync(onFailure) {
-      val receipt =
-          db.from("receipt")
-              .select(columns) { filter { SupabaseReceipt::uid eq id } }
-              .decodeSingle<SupabaseReceipt>()
-              .toReceipt()
-      onSuccess(receipt)
+    val getReceiptFromCache = { receipts: List<Receipt>? ->
+      receipts!!.find { it.uid == id }?.let { onSuccess(it) }
+          ?: onFailure(Exception("Receipt not found"))
     }
+
+    if (userReceipts != null && userUid == CurrentUser.userUid) {
+      getReceiptFromCache(userReceipts)
+      return
+    }
+
+    updateUserCache(getReceiptFromCache, onFailure)
   }
 
   /**
@@ -141,10 +193,12 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
    * @param onFailure called whenever an error has occurred with the exception that occurred
    */
   fun getAllReceipts(onSuccess: (List<Receipt>) -> Unit, onFailure: (Exception) -> Unit) {
-    tryAsync(onFailure) {
-      val select = db.from("receipt").select(columns)
-      onSuccess(select.decodeList<SupabaseReceipt>().map { it.toReceipt() })
+    if (receipts != null) {
+      onSuccess(receipts!!)
+      return
     }
+
+    updateCache(onSuccess, onFailure)
   }
 
   /**

--- a/app/src/test/java/com/github/se/assocify/model/database/ReceiptsAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/ReceiptsAPITest.kt
@@ -195,6 +195,10 @@ class ReceiptsAPITest {
     api.getReceipt(remoteReceipt.uid, successMock, { fail("Should not fail, failed with $it") })
     verify(timeout = 1000) { successMock(remoteReceipt) }
 
+    val failureMock1 = mockk<(Exception) -> Unit>(relaxed = true)
+    api.getReceipt(localReceipt.uid, { fail("Should not succeed") }, failureMock1)
+    verify(timeout = 1000) { failureMock1.invoke(any()) }
+
     // Change the UID to invalidate the cache
     CurrentUser.userUid = "DEADBEEF-1000-0000-0000-000000000000"
 


### PR DESCRIPTION
Adds receipt caching, as well as a method to update the caches (i.e. refresh the lists).

The cache is split into two parts, the user receipts and the global receipts.

Completes part of #206.