### PR TITLE
Category and subcategory caching

### DIFF
--- a/app/src/main/java/com/github/se/assocify/AssocifyApp.kt
+++ b/app/src/main/java/com/github/se/assocify/AssocifyApp.kt
@@ -24,6 +24,9 @@ import com.github.se.assocify.navigation.mainNavGraph
 fun AssocifyApp(loginSaver: LoginSave) {
   val navController = rememberNavController()
   val navActions = NavigationActions(navController, loginSaver)
+
+  loginSaver.loadUserInfo()
+
   val userAPI = UserAPI(SupabaseClient.supabaseClient)
   val associationAPI = AssociationAPI(SupabaseClient.supabaseClient)
   val eventAPI = EventAPI(SupabaseClient.supabaseClient)
@@ -34,7 +37,6 @@ fun AssocifyApp(loginSaver: LoginSave) {
   val accountingCategoriesAPI = AccountingCategoryAPI(SupabaseClient.supabaseClient)
   val accountingSubCategoryAPI = AccountingSubCategoryAPI(SupabaseClient.supabaseClient)
   val balanceAPI = BalanceAPI(SupabaseClient.supabaseClient)
-  loginSaver.loadUserInfo()
 
   val firstDest =
       if (CurrentUser.userUid != null && CurrentUser.associationUid != null) {

--- a/app/src/main/java/com/github/se/assocify/model/database/AccountingCategoryAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AccountingCategoryAPI.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify.model.database
 
+import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingCategory
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
@@ -12,6 +13,10 @@ class AccountingCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
 
   private var categoryCache: List<AccountingCategory>? = null
   private var categoryCacheAssociationUID: String? = null
+
+  init {
+    CurrentUser.associationUid?.let { updateCategoryCache(it, {}, {}) }
+  }
 
   /**
    * Get the categories of an association, but force an update of the cache

--- a/app/src/main/java/com/github/se/assocify/model/database/AccountingCategoryAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AccountingCategoryAPI.kt
@@ -2,13 +2,40 @@ package com.github.se.assocify.model.database
 
 import com.github.se.assocify.model.entities.AccountingCategory
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.postgrest.postgrest
+import io.github.jan.supabase.postgrest.from
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class AccountingCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
 
   private val collectionName = "accounting_category"
+
+  private var categoryCache: List<AccountingCategory>? = null
+  private var categoryCacheAssociationUID: String? = null
+
+  /**
+   * Get the categories of an association, but force an update of the cache
+   *
+   * @param associationUID the unique identifier of the association
+   * @param onSuccess the callback to be called when the categories are retrieved
+   * @param onFailure the callback to be called when the categories could not be retrieved
+   */
+  fun updateCategoryCache(
+      associationUID: String,
+      onSuccess: (List<AccountingCategory>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    tryAsync(onFailure) {
+      val categories =
+          db.from(collectionName)
+              .select { filter { SupabaseAccountingCategory::associationUID eq associationUID } }
+              .decodeList<SupabaseAccountingCategory>()
+              .map { it.toAccountingCategory() }
+      categoryCache = categories
+      categoryCacheAssociationUID = associationUID
+      onSuccess(categories)
+    }
+  }
 
   /**
    * Get the categories of an association
@@ -23,13 +50,10 @@ class AccountingCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       onSuccess: (List<AccountingCategory>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    tryAsync(onFailure) {
-      val categories =
-          db.postgrest
-              .from(collectionName)
-              .select { filter { SupabaseAccountingCategory::associationUID eq associationUID } }
-              .decodeList<SupabaseAccountingCategory>()
-      onSuccess(categories.map { it.toAccountingCategory() })
+    if (categoryCacheAssociationUID == associationUID && categoryCache != null) {
+      categoryCache?.let { onSuccess(it) }
+    } else {
+      updateCategoryCache(associationUID, onSuccess, onFailure)
     }
   }
 
@@ -48,11 +72,14 @@ class AccountingCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       onFailure: (Exception) -> Unit
   ) {
     tryAsync(onFailure) {
-      db.postgrest
-          .from(collectionName)
+      db.from(collectionName)
           .insert(
               SupabaseAccountingCategory(
                   uid = category.uid, associationUID = associationUID, name = category.name))
+
+      if (categoryCacheAssociationUID == associationUID) {
+        categoryCache = categoryCache?.plus(category)
+      }
       onSuccess()
     }
   }
@@ -72,14 +99,24 @@ class AccountingCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       onFailure: (Exception) -> Unit
   ) {
     tryAsync(onFailure) {
-      db.postgrest.from(collectionName).update({
-        SupabaseAccountingCategory::name setTo category.name
-      }) {
+      db.from(collectionName).update({ SupabaseAccountingCategory::name setTo category.name }) {
         filter {
           SupabaseAccountingCategory::uid eq category.uid
           SupabaseAccountingCategory::associationUID eq associationUID
         }
       }
+
+      if (categoryCacheAssociationUID == associationUID) {
+        categoryCache =
+            categoryCache?.map {
+              if (it.uid == category.uid) {
+                category
+              } else {
+                it
+              }
+            }
+      }
+
       onSuccess()
     }
   }
@@ -97,9 +134,10 @@ class AccountingCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       onFailure: (Exception) -> Unit
   ) {
     tryAsync(onFailure) {
-      db.postgrest.from(collectionName).delete {
-        filter { SupabaseAccountingCategory::uid eq category.uid }
-      }
+      db.from(collectionName).delete { filter { SupabaseAccountingCategory::uid eq category.uid } }
+
+      categoryCache = categoryCache?.filter { it.uid != category.uid }
+
       onSuccess()
     }
   }

--- a/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
@@ -2,6 +2,7 @@ package com.github.se.assocify.model.database
 
 import com.github.se.assocify.model.entities.AccountingSubCategory
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.postgrest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,6 +14,33 @@ import kotlinx.serialization.Serializable
  */
 class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
   private val collection = "accounting_subcategory"
+
+  private var subCategoryCache: List<AccountingSubCategory>? = null
+  private var subCategoryCacheAssociationUID: String? = null
+
+  /**
+   * Get the subcategories of an association, but force an update of the cache
+   *
+   * @param associationUID the unique identifier of the association
+   * @param onSuccess the callback to be called when the subcategories are retrieved
+   * @param onFailure the callback to be called when the subcategories could not be retrieved
+   */
+  fun updateSubCategoryCache(
+      associationUID: String,
+      onSuccess: (List<AccountingSubCategory>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    tryAsync(onFailure) {
+      val subCategories =
+          db.from(collection)
+              .select { filter { SupabaseAccountingSubCategory::associationUID eq associationUID } }
+              .decodeList<SupabaseAccountingSubCategory>()
+              .map { it.toAccountingSubCategory() }
+      subCategoryCache = subCategories
+      subCategoryCacheAssociationUID = associationUID
+      onSuccess(subCategories)
+    }
+  }
 
   /**
    * Get the subcategories of an association
@@ -26,13 +54,10 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       onSuccess: (List<AccountingSubCategory>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    tryAsync(onFailure) {
-      val subCategories =
-          db.postgrest
-              .from(collection)
-              .select { filter { SupabaseAccountingSubCategory::associationUID eq associationUID } }
-              .decodeList<SupabaseAccountingSubCategory>()
-      onSuccess(subCategories.map { it.toAccountingSubCategory() })
+    if (subCategoryCacheAssociationUID == associationUID && subCategoryCache != null) {
+      onSuccess(subCategoryCache!!)
+    } else {
+      updateSubCategoryCache(associationUID, onSuccess, onFailure)
     }
   }
 
@@ -62,6 +87,9 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
                   amount = subCategory.amount,
                   year = subCategory.year))
 
+      if (subCategoryCacheAssociationUID == associationUID) {
+        subCategoryCache = subCategoryCache?.plus(subCategory)
+      }
       onSuccess()
     }
   }
@@ -87,6 +115,15 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       }) {
         filter { SupabaseAccountingSubCategory::uid eq subCategory.uid }
       }
+
+      subCategoryCache =
+          subCategoryCache?.map {
+            if (it.uid == subCategory.uid) {
+              subCategory
+            } else {
+              it
+            }
+          }
       onSuccess()
     }
   }
@@ -107,6 +144,8 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
       db.postgrest.from(collection).delete {
         filter { SupabaseAccountingSubCategory::uid eq subCategory.uid }
       }
+
+      subCategoryCache = subCategoryCache?.filter { it.uid != subCategory.uid }
       onSuccess()
     }
   }

--- a/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/AccountingSubCategoryAPI.kt
@@ -1,5 +1,6 @@
 package com.github.se.assocify.model.database
 
+import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.AccountingSubCategory
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
@@ -17,6 +18,10 @@ class AccountingSubCategoryAPI(val db: SupabaseClient) : SupabaseApi() {
 
   private var subCategoryCache: List<AccountingSubCategory>? = null
   private var subCategoryCacheAssociationUID: String? = null
+
+  init {
+    CurrentUser.associationUid?.let { updateSubCategoryCache(it, {}, {}) }
+  }
 
   /**
    * Get the subcategories of an association, but force an update of the cache

--- a/app/src/test/java/com/github/se/assocify/model/database/AccountingCategoryAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/AccountingCategoryAPITest.kt
@@ -9,6 +9,7 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondBadRequest
 import io.ktor.http.Headers
+import io.mockk.clearMocks
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.verify
@@ -62,6 +63,13 @@ class AccountingCategoryAPITest {
         """
             .trimIndent()
 
+    api.getCategories(CurrentUser.associationUid.toString(), onSuccess, onFailure)
+    verify(timeout = 400) { onSuccess(any()) }
+    clearMocks(onSuccess)
+
+    error = true
+
+    // Test cache
     api.getCategories(CurrentUser.associationUid.toString(), onSuccess, onFailure)
     verify(timeout = 400) { onSuccess(any()) }
   }

--- a/app/src/test/java/com/github/se/assocify/model/database/AccountingCategoryAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/AccountingCategoryAPITest.kt
@@ -65,13 +65,15 @@ class AccountingCategoryAPITest {
 
     api.getCategories(CurrentUser.associationUid.toString(), onSuccess, onFailure)
     verify(timeout = 400) { onSuccess(any()) }
-    clearMocks(onSuccess)
+    verify(exactly = 0) { onFailure(any()) }
+    clearMocks(onSuccess, onFailure)
 
     error = true
 
     // Test cache
     api.getCategories(CurrentUser.associationUid.toString(), onSuccess, onFailure)
     verify(timeout = 400) { onSuccess(any()) }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test
@@ -89,6 +91,7 @@ class AccountingCategoryAPITest {
         onFailure)
 
     verify(timeout = 400) { onSuccess() }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test
@@ -106,6 +109,7 @@ class AccountingCategoryAPITest {
         onFailure)
 
     verify(timeout = 400) { onSuccess() }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test
@@ -122,5 +126,6 @@ class AccountingCategoryAPITest {
         onFailure)
 
     verify(timeout = 400) { onSuccess() }
+    verify(exactly = 0) { onFailure(any()) }
   }
 }

--- a/app/src/test/java/com/github/se/assocify/model/database/AccountingSubCategoryTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/AccountingSubCategoryTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondBadRequest
 import io.ktor.http.Headers
+import io.mockk.clearMocks
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.verify
@@ -64,6 +65,15 @@ class AccountingSubCategoryTest {
     api.getSubCategories("cb7b1079-cb62-40b9-9f35-7667fea4748d", onSuccess, onFailure)
 
     verify(timeout = 400) { onSuccess(any()) }
+    verify(exactly = 0) { onFailure(any()) }
+    clearMocks(onSuccess, onFailure)
+
+    // Test cache
+    error = true
+
+    api.getSubCategories("cb7b1079-cb62-40b9-9f35-7667fea4748d", onSuccess, onFailure)
+    verify(timeout = 400) { onSuccess(any()) }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test

--- a/app/src/test/java/com/github/se/assocify/model/database/AccountingSubCategoryTest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/AccountingSubCategoryTest.kt
@@ -95,6 +95,7 @@ class AccountingSubCategoryTest {
         onSuccess,
         onFailure)
     verify(timeout = 400) { onSuccess() }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test
@@ -111,6 +112,7 @@ class AccountingSubCategoryTest {
         onSuccess,
         onFailure)
     verify(timeout = 400) { onSuccess() }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test
@@ -131,5 +133,6 @@ class AccountingSubCategoryTest {
         onSuccess,
         onFailure)
     verify(timeout = 400) { onSuccess() }
+    verify(exactly = 0) { onFailure(any()) }
   }
 }


### PR DESCRIPTION
Completes part of https://github.com/Assocify-Team/Assocify/issues/206.

This PR adds caching to the AccountCategoryAPI and AccountSubcategoryAPI. Similarly to other caching PRs, it allows manual refreshing, but not automatic.