### PR TITLE
User API caching

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -106,8 +106,9 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
     tryAsync(onFailure) {
       db.from("users").update({ User::name setTo newName }) { filter { User::uid eq userId } }
 
-      if (userCache[userId] != null) {
-        userCache[userId] = userCache[userId]!!.copy(name = newName)
+      val cachedValue = userCache[userId]
+      if (cachedValue != null) {
+        userCache[userId] = cachedValue.copy(name = newName)
       }
       onSuccess()
     }

--- a/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/UserAPI.kt
@@ -63,7 +63,6 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
    *
    * @param onSuccess called on success with the list of users
    * @param onFailure called on failure
-   * @return a list of all users
    */
   fun getAllUsers(onSuccess: (List<User>) -> Unit, onFailure: (Exception) -> Unit) {
     if (userCache.isNotEmpty()) {
@@ -216,7 +215,7 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
   }
 
   private var currentUserAssociationCache: Map<String, Pair<Association, PermissionRole>>? = null
-  private var currentUserAssociationId: String? = null
+  private var currentUserId: String? = null
 
   fun updateCurrentUserAssociationCache(
       onSuccess: (Map<String, Pair<Association, PermissionRole>>) -> Unit,
@@ -230,7 +229,7 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
               .associate { it.associationId to (it.getAssociation() to it.getRole()) }
 
       currentUserAssociationCache = associations
-      currentUserAssociationId = CurrentUser.userUid
+      currentUserId = CurrentUser.userUid
 
       onSuccess(associations)
     }
@@ -246,7 +245,7 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
       onSuccess: (List<Association>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (currentUserAssociationCache != null && currentUserAssociationId == CurrentUser.userUid) {
+    if (currentUserAssociationCache != null && currentUserId == CurrentUser.userUid) {
       onSuccess(currentUserAssociationCache!!.values.map { it.first })
     } else {
       updateCurrentUserAssociationCache({ onSuccess(it.values.map { it.first }) }, onFailure)
@@ -260,7 +259,7 @@ class UserAPI(private val db: SupabaseClient) : SupabaseApi() {
    * @param onFailure called on failure
    */
   fun getCurrentUserRole(onSuccess: (PermissionRole) -> Unit, onFailure: (Exception) -> Unit) {
-    if (currentUserAssociationCache != null && currentUserAssociationId == CurrentUser.userUid) {
+    if (currentUserAssociationCache != null && currentUserId == CurrentUser.userUid) {
       val associationUid = CurrentUser.associationUid!!
       currentUserAssociationCache!![associationUid]?.let { onSuccess(it.second) }
           ?: onFailure(Exception("Association not found"))

--- a/app/src/test/java/com/github/se/assocify/model/database/UserAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/UserAPITest.kt
@@ -1,6 +1,5 @@
 package com.github.se.assocify.model.database
 
-import android.util.Log
 import com.github.se.assocify.BuildConfig
 import com.github.se.assocify.model.CurrentUser
 import com.github.se.assocify.model.entities.Association
@@ -273,7 +272,6 @@ class UserAPITest {
 
   @Test
   fun testGetCurrentUserRole() {
-    Log.i("TEST", "Start of test")
     val onSuccess: (PermissionRole) -> Unit = mockk(relaxed = true)
 
     response =

--- a/app/src/test/java/com/github/se/assocify/model/database/UserAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/UserAPITest.kt
@@ -171,7 +171,7 @@ class UserAPITest {
       [{
         "user_id": "$uuid1",
         "role_id": "$uuid1",
-        "association_id": "$uuid1",
+        "association_id": "${APITestUtils.ASSOCIATION.uid}",
         "type": "presidency",
         "association_name": "Test",
         "association_description": "Test",
@@ -185,10 +185,10 @@ class UserAPITest {
 
     error = true
 
+    clearMocks(onSuccess)
     // Test cache
     userAPI.getCurrentUserAssociations(onSuccess, { fail("Should not fail, failed with $it") })
 
-    clearMocks(onSuccess)
     verify(timeout = 1000) { onSuccess(any()) }
 
     val onFailure: (Exception) -> Unit = mockk(relaxed = true)


### PR DESCRIPTION
Completes part of https://github.com/Assocify-Team/Assocify/issues/206.

This PR adds caching to the User API. This makes the profile page and association creation page load faster. The cache needs to be manually refreshed to receive outside updates, but it does not need to be updated manually after local changes.

Tests have not been added, but depending on current coverage I will add some.