### PR TITLE
Event API caching

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/EventAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/EventAPI.kt
@@ -13,6 +13,16 @@ class EventAPI(db: SupabaseClient) : SupabaseApi() {
 
   private var eventCache: List<Event>? = null
 
+  init {
+    updateEventCache({}, {})
+  }
+
+  /**
+   * Updates the event cache with the events from the database
+   *
+   * @param onSuccess called on success with the list of events
+   * @param onFailure called on failure
+   */
   fun updateEventCache(onSuccess: (List<Event>) -> Unit, onFailure: (Exception) -> Unit) {
     tryAsync(onFailure) {
       val events =

--- a/app/src/test/java/com/github/se/assocify/model/database/EventAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/EventAPITest.kt
@@ -82,6 +82,13 @@ class EventAPITest {
     eventAPI.getEvent("$uuid1", onSuccess, onFailure)
     verify(timeout = 200) { onSuccess(any()) }
     verify(exactly = 0) { onFailure(any()) }
+    clearMocks(onSuccess, onFailure)
+
+    error = true
+    // Test cache
+    eventAPI.getEvent("$uuid1", onSuccess, onFailure)
+    verify(timeout = 100) { onSuccess(any()) }
+    verify(exactly = 0) { onFailure(any()) }
   }
 
   @Test
@@ -114,6 +121,14 @@ class EventAPITest {
             ]
         """
             .trimIndent()
+
+    eventAPI.getEvents(onSuccess, onFailure)
+    verify(timeout = 100) { onSuccess(any()) }
+    verify(exactly = 0) { onFailure(any()) }
+    clearMocks(onSuccess, onFailure)
+
+    error = true
+    // Test cache
 
     eventAPI.getEvents(onSuccess, onFailure)
     verify(timeout = 100) { onSuccess(any()) }
@@ -171,6 +186,23 @@ class EventAPITest {
     val onSuccess: () -> Unit = mockk(relaxed = true)
     error = false
     val currentTime = OffsetDateTime.parse("2007-12-03T10:15:30+01:00")
+
+    response =
+        """
+          [{
+            "uid": "$uuid1",
+            "name": "Test Event",
+            "description": "Test Description A",
+            "start_date": "2008-12-03T10:15:30+01:00",
+            "end_date": "2008-12-03T10:15:30+01:00",
+            "guests_or_artists": "Test Guest",
+            "location": "Test Location"
+        }]
+      """
+            .trimIndent()
+    val successMockCache = mockk<(List<Event>) -> Unit>(relaxed = true)
+    eventAPI.updateEventCache(successMockCache, { fail("Should not fail") })
+    verify(timeout = 1000) { successMockCache(any()) }
 
     eventAPI.updateEvent(
         Event(


### PR DESCRIPTION
Completes part of https://github.com/Assocify-Team/Assocify/issues/206.

This PR adds caching to the Event API. The cache needs to be manually refreshed to receive outside updates, but it does not need to be updated manually after local changes.

It also replaces all the `scope.launch`es with `tryAsync`, for consistency.

Tests have not been added, but depending on current coverage I will add some.