### PR TITLE
Make text entries single line

### DIFF
--- a/app/src/main/java/com/github/se/assocify/ui/composables/UserSearchTextField.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/composables/UserSearchTextField.kt
@@ -47,6 +47,7 @@ fun UserSearchTextField(
   Column {
     OutlinedTextField(
         value = value,
+        singleLine = true,
         onValueChange = { onUserSearch(it) },
         modifier = modifier then Modifier.onSizeChanged { textfieldSize = it.width },
         readOnly = state.user != null,

--- a/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/createAssociation/CreateAssociationScreen.kt
@@ -92,6 +92,7 @@ fun CreateAssociationScreen(
                     }
                 OutlinedTextField(
                     value = state.name,
+                    singleLine = true,
                     onValueChange = { viewmodel.setName(it) },
                     label = { Text("Association Name") },
                     modifier = Modifier.fillMaxWidth().testTag("name"))

--- a/app/src/main/java/com/github/se/assocify/ui/screens/event/tasktab/task/TaskScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/event/tasktab/task/TaskScreen.kt
@@ -120,6 +120,7 @@ fun TaskScreen(navActions: NavigationActions, viewModel: TaskViewModel) {
               OutlinedTextField(
                   modifier = Modifier.testTag("titleField").fillMaxWidth(),
                   value = taskState.title,
+                  singleLine = true,
                   onValueChange = { viewModel.setTitle(it) },
                   label = { Text("Title") },
                   isError = taskState.titleError != null,
@@ -134,12 +135,14 @@ fun TaskScreen(navActions: NavigationActions, viewModel: TaskViewModel) {
               OutlinedTextField(
                   modifier = Modifier.testTag("categoryField").fillMaxWidth(),
                   value = taskState.category,
+                  singleLine = true,
                   onValueChange = { viewModel.setCategory(it) },
                   label = { Text("Category") },
                   supportingText = {})
               OutlinedTextField(
                   modifier = Modifier.testTag("staffNumberField").fillMaxWidth(),
                   value = taskState.staffNumber,
+                  singleLine = true,
                   onValueChange = { viewModel.setStaffNumber(it) },
                   label = { Text("Number of Staff") },
                   keyboardOptions =

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileScreen.kt
@@ -253,6 +253,7 @@ fun ProfileScreen(navActions: NavigationActions, viewmodel: ProfileViewModel) {
                   horizontalAlignment = Alignment.CenterHorizontally) {
                     OutlinedTextField(
                         value = state.modifyingName,
+                        singleLine = true,
                         onValueChange = { viewmodel.modifyName(it) },
                         label = { Text("Edit your name") },
                         modifier = Modifier.fillMaxWidth().testTag("editName"))

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
@@ -332,6 +332,7 @@ fun DisplayEditBudget(budgetViewModel: BudgetDetailedViewModel) {
         OutlinedTextField(
             modifier = Modifier.padding(8.dp).testTag("editNameBox"),
             value = nameString,
+            singleLine = true,
             onValueChange = { nameString = it },
             label = { Text("Name") },
             supportingText = {})
@@ -492,12 +493,14 @@ fun DisplayEditSubCategory(
                 OutlinedTextField(
                     modifier = Modifier.testTag("editSubCategoryNameBox").padding(8.dp),
                     value = name,
+                    singleLine = true,
                     onValueChange = { name = it },
                     label = { Text("Name") },
                     supportingText = {})
                 OutlinedTextField(
                     modifier = Modifier.testTag("editSubCategoryYearBox").padding(8.dp),
                     value = year,
+                    singleLine = true,
                     onValueChange = { year = it },
                     label = { Text("Year") },
                     supportingText = {})
@@ -508,6 +511,7 @@ fun DisplayEditSubCategory(
                     modifier = Modifier.testTag("categoryDropdown").padding(8.dp)) {
                       OutlinedTextField(
                           value = selectedCategory,
+                          singleLine = true,
                           onValueChange = {},
                           label = { Text("Tag") },
                           trailingIcon = {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/newcategory/AddCategoryScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/newcategory/AddCategoryScreen.kt
@@ -106,6 +106,7 @@ fun AddAccountingSubCategory(
               OutlinedTextField(
                   modifier = Modifier.testTag("categoryNameField").fillMaxWidth(),
                   value = subCategoryTitle,
+                  singleLine = true,
                   onValueChange = { subCategoryTitle = it },
                   label = { Text("Category name") },
                   supportingText = { /* TODO: Error management */})
@@ -113,6 +114,7 @@ fun AddAccountingSubCategory(
               OutlinedTextField(
                   modifier = Modifier.testTag("valueField").fillMaxWidth(),
                   value = selectedValue.toString(),
+                  singleLine = true,
                   onValueChange = { selectedValue = it.toIntOrNull() ?: 0 },
                   label = { Text("Value") },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -126,6 +128,7 @@ fun AddAccountingSubCategory(
                   modifier = Modifier.testTag("categoryDropdown")) {
                     OutlinedTextField(
                         value = selectedSubCategory,
+                        singleLine = true,
                         onValueChange = {},
                         label = { Text("Tag") },
                         trailingIcon = {
@@ -186,6 +189,7 @@ fun AddCategoryDialog(
               OutlinedTextField(
                   modifier = Modifier.testTag("newTagFieldPopup").fillMaxWidth(),
                   value = newTagName,
+                  singleLine = true,
                   onValueChange = onNewTagChange,
                   label = { Text("Tag name") },
                   supportingText = { /* TODO: Error management */})

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/receiptstab/receipt/ReceiptScreen.kt
@@ -146,6 +146,7 @@ fun ReceiptScreen(viewModel: ReceiptViewModel) {
               OutlinedTextField(
                   modifier = Modifier.testTag("titleField").fillMaxWidth(),
                   value = receiptState.title,
+                  singleLine = true,
                   onValueChange = { viewModel.setTitle(it) },
                   label = { Text("Title") },
                   isError = receiptState.titleError != null,
@@ -160,6 +161,7 @@ fun ReceiptScreen(viewModel: ReceiptViewModel) {
               OutlinedTextField(
                   modifier = Modifier.testTag("amountField").fillMaxWidth(),
                   value = receiptState.amount,
+                  singleLine = true,
                   onValueChange = { viewModel.setAmount(it) },
                   label = { Text("Amount") },
                   keyboardOptions =


### PR DESCRIPTION
Closes #331

Previously, many text entries were multi-line. This made it possible to have multi-line names, which look strange and might break the UI. This fixes that. It is local-only, but because it only causes visual glitches, it's okay that it's not in the database.