### PR TITLE
Fix Task API cache

### DIFF
--- a/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/TaskAPI.kt
@@ -187,6 +187,7 @@ class TaskAPI(private val db: SupabaseClient) : SupabaseApi() {
   fun deleteTask(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     tryAsync(onFailure) {
       db.from("task").delete { filter { SupabaseTask::uid eq id } }
+      taskCache = taskCache?.filter { it.uid != id }
       onSuccess()
     }
   }


### PR DESCRIPTION
Task api wasn't updating the cache when deleting a task. Now it is updated :)
