### PR TITLE
Fix the TVA issues on single item

### DIFF
--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/AccountingDetailedScreen.kt
@@ -307,9 +307,16 @@ fun DisplayBudgetItem(
     budgetItem: BudgetItem,
     testTag: String
 ) {
+  val budgetState by budgetDetailedViewModel.uiState.collectAsState()
   ListItem(
       headlineContent = { Text(budgetItem.nameItem) },
-      trailingContent = { Text(PriceUtil.fromCents(budgetItem.amount)) },
+      trailingContent = {
+        Text(
+            if (budgetState.filterActive)
+                PriceUtil.fromCents(
+                    budgetItem.amount + (budgetItem.amount * budgetItem.tva.rate / 100f).toInt())
+            else PriceUtil.fromCents(budgetItem.amount))
+      },
       supportingContent = { Text(budgetItem.description) },
       modifier =
           Modifier.clickable { budgetDetailedViewModel.startEditing(budgetItem) }.testTag(testTag))
@@ -327,12 +334,18 @@ fun DisplayBalanceItem(
     balanceItem: BalanceItem,
     testTag: String
 ) {
+  val balanceState by balanceDetailedViewModel.uiState.collectAsState()
   ListItem(
       headlineContent = { Text(balanceItem.nameItem) },
       trailingContent = {
         Row(verticalAlignment = Alignment.CenterVertically) {
           Text(
-              PriceUtil.fromCents(balanceItem.amount),
+              text =
+                  if (balanceState.filterActive)
+                      PriceUtil.fromCents(
+                          balanceItem.amount +
+                              (balanceItem.amount * balanceItem.tva.rate / 100f).toInt())
+                  else PriceUtil.fromCents(balanceItem.amount),
               modifier = Modifier.padding(end = 4.dp),
               style = MaterialTheme.typography.bodyMedium)
           /*Icon(


### PR DESCRIPTION
There is a little problem: the TVA on the single values is not activated when the filter of TVA is activated. The objective of this PR is to fix this single issue so it can be repaired and the TVA can be consistent everywhere.