### PR TITLE
Repair APK CI

### DIFF
--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -34,11 +34,13 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE }}
           ENCODED_PASSWORDS: ${{ secrets.KEYSTORE_PASSWORDS }}
+          ENCODED_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
 
         run: |
           echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
           echo $ENCODED_KEYSTORE | base64 -di > keystore.jks
           echo $ENCODED_PASSWORDS | base64 -di > keystore.properties
+          echo $ENCODED_PROPERTIES | base64 -di > local.properties
 
       - name: Build Release apk
         run: |


### PR DESCRIPTION
We forgot to fix the CI after M2. This PR brings that fix to the main branch. It only fixes the APK generation CI, because the testing CI doesn't need to have access to the actual database, and so it is ensured.