### PR TITLE
Add receipt owners to receipt entity

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BalanceDetailedScreenTest.kt
@@ -112,8 +112,8 @@ class BalanceDetailedScreenTest :
               LocalDate.of(2023, 3, 11),
               28,
               Status.Pending,
-              null),
-      )
+              null,
+              "userId"))
 
   val mockBalanceAPI: BalanceAPI =
       mockk<BalanceAPI>() {

--- a/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/ReceiptScreenTest.kt
@@ -45,6 +45,7 @@ class ReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   private var expectedReceipt =
       Receipt(
           uid = "08a11dc8-975c-4da1-93a6-865c20c7adec",
+          userId = "testUser",
           title = "Test Title",
           description = "",
           cents = -10000,
@@ -264,6 +265,7 @@ class EditReceiptScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.with
   private var expectedReceipt =
       Receipt(
           uid = "08a11dc8-975c-4da1-93a6-865c20c7adec",
+          userId = "testUser",
           title = "Edited Receipt",
           description = "",
           cents = -10000,

--- a/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ReceiptAPI.kt
@@ -284,7 +284,7 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
               cents = receipt.cents,
               title = receipt.title,
               description = receipt.description,
-              userId = CurrentUser.userUid!!,
+              userId = receipt.userId,
               associationId = CurrentUser.associationUid!!)
     }
 
@@ -296,7 +296,8 @@ class ReceiptAPI(private val db: SupabaseClient, private val cachePath: Path) : 
             title = this.title,
             description = this.description,
             status = this.receiptStatus!!.status,
-            photo = MaybeRemotePhoto.Remote(this.uid))
+            photo = MaybeRemotePhoto.Remote(this.uid),
+            userId = this.userId)
   }
 
   @Serializable private data class ReceiptStatus(val status: Status)

--- a/app/src/main/java/com/github/se/assocify/model/entities/Receipt.kt
+++ b/app/src/main/java/com/github/se/assocify/model/entities/Receipt.kt
@@ -25,6 +25,7 @@ data class Receipt(
     val cents: Int,
     val status: Status,
     val photo: MaybeRemotePhoto?,
+    val userId: String,
 )
 
 @Serializable

--- a/app/src/test/java/com/github/se/assocify/model/database/ReceiptsAPITest.kt
+++ b/app/src/test/java/com/github/se/assocify/model/database/ReceiptsAPITest.kt
@@ -44,6 +44,7 @@ class ReceiptsAPITest {
   private val remoteReceipt =
       Receipt(
           uid = "00000000-ABCD-0000-0000-000000000000",
+          userId = "ABCD0001-ABCD-0000-0000-000000000001",
           date = LocalDate.EPOCH,
           cents = -100,
           status = Status.Pending,
@@ -54,6 +55,7 @@ class ReceiptsAPITest {
   private val localReceipt =
       Receipt(
           uid = "00000001-ABCD-0000-0000-000000000001",
+          userId = "ABCD0001-ABCD-0000-0000-000000000001",
           date = LocalDate.EPOCH,
           cents = -100,
           status = Status.Approved,
@@ -72,7 +74,7 @@ class ReceiptsAPITest {
         },
         "title": "title",
         "description": "notes",
-        "user_id": "2c256037-ad67-4185-991a-1a2b9bb1f9b3",
+        "user_id": "ABCD0001-ABCD-0000-0000-000000000001",
         "association_id": "2c256037-4185-ad67-991a-1a2b9bb1f9b3"
       }
     """
@@ -89,7 +91,7 @@ class ReceiptsAPITest {
         },
         "title": "title",
         "description": "notes",
-        "user_id": "2c256037-ad67-4185-991a-1a2b9bb1f9b3",
+        "user_id": "ABCD0001-ABCD-0000-0000-000000000001",
         "association_id": "2c256037-4185-ad67-991a-1a2b9bb1f9b3"
       }
     """


### PR DESCRIPTION
Closes #306.

This PR adds a `userId` field to `Receipt`, which already existed in the database but was simply not linked. This PR also makes editing receipts not transfer their owner.