### PR TITLE
Profile pictures for users

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/Epic1Test.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/Epic1Test.kt
@@ -126,6 +126,15 @@ class Epic1Test : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
               val onSuccessCallback = firstArg<(PermissionRole) -> Unit>()
               onSuccessCallback.invoke(PermissionRole("1", "aaa", RoleType.PRESIDENCY))
             }
+
+        // Never return a profile picture, permanently "fetch" the profile picture
+        every { getProfilePicture(any(), any(), any()) } answers {}
+
+        every { setProfilePicture(any(), any(), any(), any()) } answers
+            {
+              val onSuccessCallback = thirdArg<() -> Unit>()
+              onSuccessCallback()
+            }
       }
 
   private val eventAPI = mockk<EventAPI>() { every { getEvents(any(), any()) } answers {} }

--- a/app/src/androidTest/java/com/github/se/assocify/Epic4Test.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/Epic4Test.kt
@@ -138,6 +138,15 @@ class Epic4Test : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSuppo
                 onSuccessCallback.invoke(PermissionRole("1", "b", RoleType.PRESIDENCY))
               }
             }
+
+        // Never return a profile picture, permanently "fetch" the profile picture
+        every { getProfilePicture(any(), any(), any()) } answers {}
+
+        every { setProfilePicture(any(), any(), any(), any()) } answers
+            {
+              val onSuccessCallback = thirdArg<() -> Unit>()
+              onSuccessCallback()
+            }
       }
 
   private val eventAPI = mockk<EventAPI>() {}

--- a/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
@@ -304,4 +304,20 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
       onNodeWithTag("errorMessage").assertIsDisplayed().assertTextContains("Error loading role")
     }
   }
+
+  @Test
+  fun openProfileSheet() {
+    with(composeTestRule) {
+      onNodeWithTag("profilePicture").performClick()
+      onNodeWithTag("photoSelectionSheet").assertIsDisplayed()
+      mViewmodel.signalCameraPermissionDenied()
+      onNodeWithTag("snackbar").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun setUri() {
+    mViewmodel.setImage(mockk())
+    with(composeTestRule) { onNodeWithTag("profilePicture").assertIsDisplayed() }
+  }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
@@ -308,7 +308,7 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   @Test
   fun openProfileSheet() {
     with(composeTestRule) {
-      onNodeWithTag("profilePicture").performClick()
+      onNodeWithTag("default profile icon").performClick()
       onNodeWithTag("photoSelectionSheet").assertIsDisplayed()
       mViewmodel.signalCameraPermissionDenied()
       onNodeWithTag("snackbar").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
@@ -88,7 +88,11 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
             }
 
         // Never return a profile picture, permanently "fetch" the profile picture
-        every { getProfilePicture(any(), any(), any()) } answers {}
+        every { getProfilePicture(any(), any(), any()) } answers
+            {
+              val onSuccessCallback = secondArg<(Uri) -> Unit>()
+              onSuccessCallback(mockk())
+            }
 
         every { setProfilePicture(any(), any(), any(), any()) } answers
             {
@@ -316,8 +320,13 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
   }
 
   @Test
-  fun setUri() {
-    mViewmodel.setImage(mockk())
-    with(composeTestRule) { onNodeWithTag("profilePicture").assertIsDisplayed() }
+  fun setUriFailure() {
+    every { mockUserAPI.getProfilePicture(any(), any(), any()) } answers
+        {
+          val onFailureCallback = thirdArg<(Exception) -> Unit>()
+          onFailureCallback(Exception("Testing error"))
+        }
+    mViewmodel.loadProfile()
+    with(composeTestRule) { onNodeWithTag("snackbar").assertIsDisplayed() }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
@@ -3,6 +3,7 @@ package com.github.se.assocify.screens.profile
 import android.net.Uri
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -88,11 +89,7 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
             }
 
         // Never return a profile picture, permanently "fetch" the profile picture
-        every { getProfilePicture(any(), any(), any()) } answers
-            {
-              val onSuccessCallback = secondArg<(Uri) -> Unit>()
-              onSuccessCallback(mockk())
-            }
+        every { getProfilePicture(any(), any(), any()) } answers {}
 
         every { setProfilePicture(any(), any(), any(), any()) } answers
             {
@@ -328,5 +325,16 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
         }
     mViewmodel.loadProfile()
     with(composeTestRule) { onNodeWithTag("snackbar").assertIsDisplayed() }
+  }
+
+  @Test
+  fun setUriSuccess() {
+    every { mockUserAPI.getProfilePicture(any(), any(), any()) } answers
+        {
+          val onSuccessCallback = secondArg<(Uri) -> Unit>()
+          onSuccessCallback(mockk())
+        }
+    mViewmodel.loadProfile()
+    with(composeTestRule) { onNodeWithTag("snackbar").assertIsNotDisplayed() }
   }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
@@ -337,4 +337,19 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
     mViewmodel.loadProfile()
     with(composeTestRule) { onNodeWithTag("snackbar").assertIsNotDisplayed() }
   }
+
+  @Test
+  fun displayProfilePictureError() {
+    every { mockUserAPI.setProfilePicture(any(), any(), any(), any()) } answers
+        {
+          val onFailureCallback = arg<(Exception) -> Unit>(3)
+          onFailureCallback(Exception("Testing error"))
+        }
+    with(composeTestRule) {
+      onNodeWithTag("default profile icon").assertIsDisplayed()
+      onNodeWithTag("default profile icon").assertHasClickAction()
+      mViewmodel.setImage(uri)
+      assert(mViewmodel.uiState.value.profileImageURI != null)
+    }
+  }
 }

--- a/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/profile/ProfileScreenTest.kt
@@ -86,6 +86,15 @@ class ProfileScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComp
               val onSuccessCallback = firstArg<(PermissionRole) -> Unit>()
               onSuccessCallback(PermissionRole("1", "asso", RoleType.PRESIDENCY))
             }
+
+        // Never return a profile picture, permanently "fetch" the profile picture
+        every { getProfilePicture(any(), any(), any()) } answers {}
+
+        every { setProfilePicture(any(), any(), any(), any()) } answers
+            {
+              val onSuccessCallback = thirdArg<() -> Unit>()
+              onSuccessCallback()
+            }
       }
 
   private lateinit var mViewmodel: ProfileViewModel

--- a/app/src/main/java/com/github/se/assocify/model/database/ImageCacher.kt
+++ b/app/src/main/java/com/github/se/assocify/model/database/ImageCacher.kt
@@ -79,6 +79,11 @@ class ImageCacher(val timeout: Long, val cacheDir: Path, private val bucket: Buc
       onFailure(it)
     }) {
       bucket.downloadAuthenticatedTo(pathInBucket, tmpImageCacheFile.toPath())
+      if (tmpImageCacheFile.length() < 100L) {
+        // Instead of throwing an exception, the bucket API writes a file with the error JSON.
+        // So we do this...
+        throw Exception("Image not found")
+      }
       val renamed = tmpImageCacheFile.renameTo(imageFile.toFile())
       if (!renamed) {
         Log.w("IMG", "Failed to rename temporary image cache file ($pathInBucket)")

--- a/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/profile/ProfileViewModel.kt
@@ -85,6 +85,15 @@ class ProfileViewModel(
           endLoading()
         },
         { endLoading("Error loading profile") })
+    userAPI.getProfilePicture(
+        "${CurrentUser.userUid!!}.jpg",
+        { uri -> _uiState.value = _uiState.value.copy(profileImageURI = uri) },
+        {
+          CoroutineScope(Dispatchers.Main).launch {
+            _uiState.value.snackbarHostState.showSnackbar(
+                message = "Error loading profile picture", duration = SnackbarDuration.Short)
+          }
+        })
     userAPI.getCurrentUserAssociations(
         { associations ->
           _uiState.value =
@@ -229,6 +238,17 @@ class ProfileViewModel(
    */
   fun setImage(uri: Uri?) {
     if (uri == null) return
+
+    userAPI.setProfilePicture(
+        "${CurrentUser.userUid!!}.jpg",
+        uri,
+        {},
+        {
+          CoroutineScope(Dispatchers.Main).launch {
+            _uiState.value.snackbarHostState.showSnackbar(
+                message = "Couldn't change profile picture", duration = SnackbarDuration.Short)
+          }
+        })
     _uiState.value = _uiState.value.copy(profileImageURI = uri)
   }
 


### PR DESCRIPTION
Closes #262. This PR adds the ability to add and load profile pictures. If the image cannot be fetched, the default icon is displayed and an error is shown, but the page still loads, because it is not a core functionality.

Still needs to be done: refresh the profile picture on reload.