### PR TITLE
Bug fix: amount in budget can be negative

### DIFF
--- a/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/assocify/screens/BudgetDetailedScreenTest.kt
@@ -408,6 +408,21 @@ class BudgetDetailedScreenTest :
   }
 
   @Test
+  fun testNegativeAmount() {
+    with(composeTestRule) {
+      onNodeWithTag("createNewItem").performClick()
+      onNodeWithTag("editDialogBox").assertIsDisplayed()
+      onNodeWithTag("editNameBox").performTextClearance()
+      onNodeWithTag("editNameBox").performTextInput("fees")
+      onNodeWithTag("editAmountBox").performTextClearance()
+      onNodeWithTag("editAmountBox").performTextInput("-5")
+      onNodeWithTag("editConfirmButton").performClick()
+      assert(!budgetDetailedViewModel.uiState.value.amountError)
+      onNodeWithTag("editDialogBox").assertIsNotDisplayed()
+    }
+  }
+
+  @Test
   fun deleteTest() {
     with(composeTestRule) {
       onNodeWithText("pair of scissors").assertIsDisplayed()

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedViewModel.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetDetailedViewModel.kt
@@ -279,11 +279,7 @@ class BudgetDetailedViewModel(
   fun setAmount(amount: String) {
     _uiState.value =
         _uiState.value.copy(
-            amountError =
-                amount.isEmpty() ||
-                    amount.toDoubleOrNull() == null ||
-                    amount.toDouble() < 0.0 ||
-                    isTooLarge(amount))
+            amountError = amount.isEmpty() || amount.toDoubleOrNull() == null || isTooLarge(amount))
   }
 
   fun setDescription(description: String) {

--- a/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetPopUpScreen.kt
+++ b/app/src/main/java/com/github/se/assocify/ui/screens/treasury/accounting/budget/BudgetPopUpScreen.kt
@@ -116,7 +116,7 @@ fun BudgetPopUpScreen(budgetViewModel: BudgetDetailedViewModel) {
                 item {
                   OutlinedTextField(
                       singleLine = true,
-                      modifier = Modifier.padding(8.dp),
+                      modifier = Modifier.padding(8.dp).testTag("editAmountBox"),
                       value = amountString,
                       isError = budgetModel.amountError,
                       onValueChange = {


### PR DESCRIPTION
This PR enables the fact that amount in budgets can be negative. Of course, you can budget an expense... There was just a check in the viiewmodel that I removed.